### PR TITLE
Added LayerConstants, closes #91

### DIFF
--- a/Singularity/Singularity/Libraries/Primitives2D.cs
+++ b/Singularity/Singularity/Libraries/Primitives2D.cs
@@ -361,7 +361,8 @@ namespace Singularity.Libraries
 		/// <param name="point2">The second point</param>
 		/// <param name="color">The color to use</param>
 		/// <param name="thickness">The thickness of the line</param>
-		public static void DrawLine(this SpriteBatch spriteBatch, Vector2 point1, Vector2 point2, Color color, float thickness)
+		/// <param name="layerDepth">The depth of the layer this gets drawn to</param>
+		public static void DrawLine(this SpriteBatch spriteBatch, Vector2 point1, Vector2 point2, Color color, float thickness, float layerDepth = 0)
 		{
 			// calculate the distance between the two vectors
 			float distance = Vector2.Distance(point1, point2);
@@ -387,16 +388,17 @@ namespace Singularity.Libraries
 		}
 
 
-		/// <summary>
-		/// Draws a line from point1 to point2 with an offset
-		/// </summary>
-		/// <param name="spriteBatch">The destination drawing surface</param>
-		/// <param name="point">The starting point</param>
-		/// <param name="length">The length of the line</param>
-		/// <param name="angle">The angle of this line from the starting point</param>
-		/// <param name="color">The color to use</param>
-		/// <param name="thickness">The thickness of the line</param>
-		public static void DrawLine(this SpriteBatch spriteBatch, Vector2 point, float length, float angle, Color color, float thickness)
+        /// <summary>
+        /// Draws a line from point1 to point2 with an offset
+        /// </summary>
+        /// <param name="spriteBatch">The destination drawing surface</param>
+        /// <param name="point">The starting point</param>
+        /// <param name="length">The length of the line</param>
+        /// <param name="angle">The angle of this line from the starting point</param>
+        /// <param name="color">The color to use</param>
+        /// <param name="thickness">The thickness of the line</param>
+        /// <param name="layerDepth">The depth of the layer this gets drawn to</param>
+        public static void DrawLine(this SpriteBatch spriteBatch, Vector2 point, float length, float angle, Color color, float thickness, float layerDepth = 0)
 		{
 			if (sPixel == null)
 			{
@@ -412,7 +414,7 @@ namespace Singularity.Libraries
 			                 Vector2.Zero,
 			                 new Vector2(length, thickness),
 			                 SpriteEffects.None,
-			                 0);
+			                 layerDepth);
 		}
 
 		#endregion

--- a/Singularity/Singularity/Map/Map.cs
+++ b/Singularity/Singularity/Map/Map.cs
@@ -58,7 +58,12 @@ namespace Singularity.Map
             //draw the background texture
             spriteBatch.Draw(mBackgroundTexture,
                 new Rectangle(0, 0, MapConstants.MapWidth, MapConstants.MapHeight),
-                Color.White);
+                null,
+                Color.White,
+                0f,
+                Vector2.Zero,
+                SpriteEffects.None,
+                LayerConstants.MapLayer);
 
             mStructureMap.Draw(spriteBatch);
 

--- a/Singularity/Singularity/Singularity.csproj
+++ b/Singularity/Singularity/Singularity.csproj
@@ -59,6 +59,7 @@
     <Compile Include="platform\Action.cs" />
     <Compile Include="platform\Job.cs" />
     <Compile Include="platform\PlatformBlank.cs" />
+    <Compile Include="Property\LayerConstants.cs" />
     <Compile Include="Screen\GameScreen.cs" />
     <Compile Include="Units\GeneralUnit.cs" />
     <Compile Include="platform\Road.cs" />

--- a/Singularity/Singularity/Units/MilitaryUnit.cs
+++ b/Singularity/Singularity/Units/MilitaryUnit.cs
@@ -113,7 +113,7 @@ namespace Singularity.Units
             if (!selected) { color = Color.White; }
             else { color = Color.Gainsboro; }
 
-            spriteBatch.Draw(mMilSheet, mPosition, new Rectangle((150 * columnNumber), (75 * rowNumber), 150, 75),color);
+            spriteBatch.Draw(mMilSheet, mPosition, new Rectangle((150 * columnNumber), (75 * rowNumber), 150, 75), color, 0f, Vector2.Zero, Vector2.One, SpriteEffects.None, LayerConstants.MilitaryUnitLayer);
 
         }
 

--- a/Singularity/Singularity/platform/PlatformBlank.cs
+++ b/Singularity/Singularity/platform/PlatformBlank.cs
@@ -180,16 +180,17 @@ namespace Singularity.platform
         {
             // the sprite sheet is 148x1744 px, 1x12 sprites
             // The sprites have different heights so, by testing I found out the sprite is about 148x170 px
-            spritebatch.Draw(
-                mSpritesheet,
+
+            spritebatch.Draw(mSpritesheet,
                 new Rectangle(
-                    (int) AbsolutePosition.X,
-                    (int) AbsolutePosition.Y,
-                    (int) AbsoluteSize.X,
-                    (int) AbsoluteSize.Y),
-                new Rectangle(0, 0, (int) AbsoluteSize.X, (int) AbsoluteSize.Y),
-                Color.White
-            );
+                    (int)AbsolutePosition.X,
+                    (int)AbsolutePosition.Y,
+                    (int)AbsoluteSize.X,
+                    (int)AbsoluteSize.Y),
+                new Rectangle(0, 0, (int)AbsoluteSize.X, (int)AbsoluteSize.Y),
+                Color.White,
+                0f, 
+                Vector2.Zero, SpriteEffects.None, LayerConstants.PlatformLayer);
         }
 
         /// <inheritdoc cref="Singularity.property.IUpdate"/>

--- a/Singularity/Singularity/platform/Road.cs
+++ b/Singularity/Singularity/platform/Road.cs
@@ -42,7 +42,7 @@ namespace Singularity.platform
 
         public void Draw(SpriteBatch spriteBatch)
         {
-            spriteBatch.DrawLine(Origin, Destination, mBlueprint? new Color(new Vector3(46, 53, 97)) : new Color(new Vector4(0, 40, 40, 255)), 5f);
+            spriteBatch.DrawLine(Origin, Destination, mBlueprint? new Color(new Vector3(46, 53, 97)) : new Color(new Vector4(0, 40, 40, 255)), 5f, LayerConstants.RoadLayer);
         }
     }
 }

--- a/Singularity/Singularity/property/LayerConstants.cs
+++ b/Singularity/Singularity/property/LayerConstants.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Singularity.Property
+{
+    
+    /// <summary>
+    /// Provides layer values for the different game objects. The smaller the value the more in the back the unit
+    /// gets drawn. The idea for this class was this we can dynamically add and change values without having to
+    /// touch the actual draw code at all. These constants should be used for the layerDepth argument
+    /// in the Draw() method for the sprite batch.
+    /// </summary>
+    internal static class LayerConstants
+    {
+        /// <summary>
+        /// A float depicting the layer for the map
+        /// </summary>
+        public const float MapLayer = 0.0f;
+
+        /// <summary>
+        /// A float depicting the layer for resources
+        /// </summary>
+        public const float ResourceLayer = 0.1f;
+
+        /// <summary>
+        /// A float depicting the layer for military units
+        /// </summary>
+        public const float MilitaryUnitLayer = 0.2f;
+
+        /// <summary>
+        /// A float depicting the layer for roads
+        /// </summary>
+        public const float RoadLayer = 0.3f;
+
+        /// <summary>
+        /// A float depicting the layer for platforms
+        /// </summary>
+        public const float PlatformLayer = 0.4f;
+
+        /// <summary>
+        /// A float depicting the layer for general units
+        /// </summary>
+        public const float GeneralUnitLayer = 0.5f;
+
+    }
+}

--- a/Singularity/Singularity/screen/GameScreen.cs
+++ b/Singularity/Singularity/screen/GameScreen.cs
@@ -37,7 +37,7 @@ namespace Singularity.screen
 
         public void Draw(SpriteBatch spriteBatch)
         {
-            spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, null, null, null, null, mMap.GetCamera().GetTransform());
+            spriteBatch.Begin(SpriteSortMode.FrontToBack, BlendState.AlphaBlend, null, null, null, null, mMap.GetCamera().GetTransform());
 
             foreach (var drawable in mDrawables)
             {


### PR DESCRIPTION
- Changed every draw method so it incorporates the new LayerConstants in their draw method.

- The new LayerConstants provide constant values to depict the layer of each object stated. This allows for dynamic adjustment

- Also changed the SpriteSortMode from Deferred to FrontToBack to actually make the layer changes visible

- The current Layer structure is as follows:
MapLayer -> ResourceLayer -> MilitiaryUnitLayer -> RoadLayer -> PlatformLayer -> GeneralUnitLayer

- Also changed the Primitives2D library to use the layer depth as an argument to simplify road drawing.