### PR TITLE
Improved the fog of war

### DIFF
--- a/Singularity/Singularity/Content/Content.mgcb
+++ b/Singularity/Singularity/Content/Content.mgcb
@@ -104,7 +104,6 @@
 /build:Glow.png
 
 #begin Dome.png
-
 /importer:TextureImporter
 /processor:TextureProcessor
 /processorParam:ColorKeyColor=255,0,255,255
@@ -127,7 +126,6 @@
 /processorParam:MakeSquare=False
 /processorParam:TextureFormat=Color
 /build:HoloProjection.png
-
 
 #begin PlatformBasic.png
 /importer:TextureImporter
@@ -209,6 +207,7 @@
 /processorParam:MakeSquare=False
 /processorParam:TextureFormat=Color
 /build:SelectorTriangle.png
+
 #begin Sound/Tutorial_Build.mp3
 /importer:Mp3Importer
 /processor:SongProcessor

--- a/Singularity/Singularity/Game1.cs
+++ b/Singularity/Singularity/Game1.cs
@@ -71,6 +71,7 @@ namespace Singularity
 
             // XSerializer.TestSerialization();
             IsMouseVisible = true;
+            mGraphics.PreferredDepthStencilFormat = DepthFormat.Depth24Stencil8;
             mGraphics.PreferredBackBufferWidth = 1080;
             mGraphics.PreferredBackBufferHeight = 720;
             mGraphics.IsFullScreen = false;
@@ -91,7 +92,7 @@ namespace Singularity
             // Create a new SpriteBatch, which can be used to draw textures.
             mSpriteBatch = new SpriteBatch(GraphicsDevice);
 
-            mGameScreen = new GameScreen(mGraphics.GraphicsDevice.Viewport, mInputManager);
+            mGameScreen = new GameScreen(mGraphics.GraphicsDevice, mInputManager);
 
             mMainMenuManager = new MainMenuManagerScreen(viewportResolution, mScreenManager, true, this);
 

--- a/Singularity/Singularity/Map/Camera.cs
+++ b/Singularity/Singularity/Map/Camera.cs
@@ -52,10 +52,6 @@ namespace Singularity.Map
         /// </summary>
         private readonly Rectangle mBounds;
 
-        /// <summary>
-        /// The scroll wheel value which is always 1 update behind the actual update.
-        /// </summary>
-        private int mOldScrollWheelValue;
 
         /// <summary>
         /// Creates a new Camera object which provides a transform matrix to adjust
@@ -80,7 +76,6 @@ namespace Singularity.Map
             mY = y;
             mViewport = viewport;
             mZoom = 1.0f;
-            mOldScrollWheelValue = 0;
             mBounds = new Rectangle(0, 0, MapConstants.MapWidth, MapConstants.MapHeight);
 
             inputManager.AddKeyListener(this);
@@ -255,6 +250,19 @@ namespace Singularity.Map
             {
                 mZoom += scrollChange;
             }
+        }
+
+        public Matrix GetStencilProjection()
+        {
+
+            var cameraWorldMin = Vector2.Transform(Vector2.Zero, Matrix.Invert(mTransform));
+
+            return Matrix.CreateOrthographicOffCenter(cameraWorldMin.X,
+                cameraWorldMin.X + (mViewport.Width / mZoom),
+                cameraWorldMin.Y + (mViewport.Height / mZoom),
+                cameraWorldMin.Y,
+                0,
+                1);
         }
     }
 }

--- a/Singularity/Singularity/Map/FogOfWar.cs
+++ b/Singularity/Singularity/Map/FogOfWar.cs
@@ -12,9 +12,25 @@ namespace Singularity.Map
     /// <inheritdoc cref="IDraw"/>
     /// <remarks>
     /// The FogOfWar grays out areas which are not "visible" from the current state of the game. Platforms and Units can
-    /// discover new areas which is why they possess a light circle around them.
+    /// discover new areas which is why they possess a light circle around them. The way this is accomplished is by using
+    /// the stencil buffer and alpha effects. I can give a short but thorough explanation of whats going on:
+    /// We basically add a completely transparent mask on the map (circle shape). Then we set every pixel
+    /// thats not transparent to 1 in the stencil buffer (the inside of the circle is internally not handled
+    /// transparent, thus we have on every pixel inside the circle a 1 in the stencil buffer, and the rest is 0)
+    /// The reason everything else is 0 is due to the AlphaEffect. Then we start drawing all our (spatial) graphics
+    /// if the value in the stencil buffer at that position is 1. So only on the inside of the circle. This creates
+    /// a "cut off" effect of the circle on the inside. The only thing left is the "gray fog" everywhere where
+    /// nothing is revealed. This we achieve by "inverting the mask", we don't actually do that but its the same
+    /// effect. Internally we draw a rectangle over the whole screen (in semi transparent black) everywhere
+    /// where the stencil is not 1. So on everything outside of the circle. This way we applied a gray fog
+    /// out of the circle. We create multiple circle masks (for every object). This way we achieve exactly
+    /// what we want. The performance is WAY better than the former one. I haven't looked into the
+    /// monogames spriteBatch.Begin() method, but we call it 4 times, and always use a different stencil state for it.
+    /// So it basically has to atleast traverse all the pixels on the screen 4 times per draw. This is done anyways for
+    /// all the different buffer in the background (ColorBuffer, DepthBuffer, VertexBuffer, ...) so it shouldn't really
+    /// add that much extra performance on the gpu.
     /// </remarks>
-    internal sealed class FogOfWar : IDraw, IUpdate
+    internal sealed class FogOfWar : IUpdate
     {
         
         /// <summary>
@@ -28,74 +44,109 @@ namespace Singularity.Map
         private readonly LinkedList<IRevealing> mRevealingObjects;
 
         /// <summary>
-        /// The background texture of the map.
+        /// A stencil state which is used to initialize the stencil buffer
+        /// with ones for every non transparent pixel, and 0 for every
+        /// transparent pixel.
         /// </summary>
-        private readonly Texture2D mMapTexture;
+        private readonly DepthStencilState mInitializeMaskStencilState;
 
         /// <summary>
-        /// Creates a new FogOfWar object for the given mapTexture. This texture should be backed by the actual map background texture
-        /// AND its dimensions should be backed by the dimensions specified in MapConstants.MapWidth and MapConstants.MapHeight.
+        /// A stencil state which is used to draw outside of every mask
+        /// currently applied in the stencil buffer.
+        /// </summary>
+        private readonly DepthStencilState mApplyInvertedMaskStencilState;
+
+        private DepthStencilState mApplyMaskStencilState;
+
+        /// <summary>
+        /// The AlphaTestEffect compares alpha values of pixels and sets them given certain restraints.
+        /// </summary>
+        private readonly AlphaTestEffect mAlphaComparator;
+
+        /// <summary>
+        /// The camera object of the game used for screen coordinae calculation.
+        /// </summary>
+        private readonly Camera mCamera;
+
+        /// <summary>
+        /// Creates a new FogOfWar object for the given mapTexture.
         /// </summary>
         /// <param name="mapTexture">The texture of the map mentioned</param>
-        public FogOfWar(Texture2D mapTexture)
+        public FogOfWar(Camera camera, GraphicsDevice graphicsDevice)
         {
+
+            mCamera = camera;
+
             mRevealingObjects = new LinkedList<IRevealing>();
 
-            mMapTexture = mapTexture;
+            mInitializeMaskStencilState = new DepthStencilState()
+            {
+                StencilEnable = true,
+                StencilFunction = CompareFunction.Always,
+                StencilPass = StencilOperation.Replace,
+                ReferenceStencil = 1,
+                DepthBufferEnable = false,
+            };
 
-            // make sure the resolution of the fog of war is as dense as the collision map
-            mToDraw = new bool[
-                (MapConstants.MapWidth / MapConstants.GridWidth),
-                (MapConstants.MapHeight / MapConstants.GridHeight)
-            ];
+
+            mApplyMaskStencilState = new DepthStencilState()
+            {
+                StencilEnable = true,
+                StencilFunction = CompareFunction.LessEqual,
+                StencilPass = StencilOperation.Replace,
+                ReferenceStencil = 1,
+                DepthBufferEnable = false,
+            };
+
+            mApplyInvertedMaskStencilState = new DepthStencilState()
+            {
+                StencilEnable = true,
+                StencilFunction = CompareFunction.Greater,
+                StencilPass = StencilOperation.Replace,
+                ReferenceStencil = 1,
+                DepthBufferEnable = false,
+            };
+
+
+            mAlphaComparator = new AlphaTestEffect(graphicsDevice)
+            {
+                Projection = mCamera.GetStencilProjection(),
+                VertexColorEnabled = true,
+                DiffuseColor = Color.White.ToVector3(),
+                AlphaFunction = CompareFunction.Always,
+                ReferenceAlpha = 0,
+            };
+
         }
 
-
-        public void Draw(SpriteBatch spriteBatch)
+        /// <summary>
+        /// Draws the revealing circles around the units in a transparent fashion.
+        /// </summary>
+        /// <param name="spriteBatch"></param>
+        public void DrawMasks(SpriteBatch spriteBatch)
         {
-            // basically we need to iterate through the whole array and draw a gray layer above the map if the position is unvisited
-            for (var i = 0; i < mToDraw.GetLength(0); i++)
+            spriteBatch.Begin(SpriteSortMode.FrontToBack, BlendState.AlphaBlend, null, mInitializeMaskStencilState, null, mAlphaComparator, mCamera.GetTransform());
+
+            foreach (var revealing in mRevealingObjects)
             {
-                for (var j = 0; j < mToDraw.GetLength(1); j++)
-                {
-                    if (mToDraw[i, j])
-                    {
-                        continue;
-                    }
-                    
-                    /*
-                     * This is definitely sub-optimal. But we need to recall that spriteBatch can only operate on rectangles.
-                     * Thus we somehow make the illusion that objects are cut off behind the fog of war and only partially
-                     * visible if their appearance is only partially visible. This can be achieved by the following method
-                     * of redrawing the map in its pieces over the density of the array used here and leaving the spaces blank
-                     * which are visited.
-                     */
-                    spriteBatch.Draw(
-                        mMapTexture,
-                        new Rectangle((int)(i * (MapConstants.GridWidth)), (int) j * MapConstants.GridHeight, MapConstants.GridWidth, MapConstants.GridHeight),
-                        new Rectangle((int) (i * (MapConstants.GridWidth)), (int) j * MapConstants.GridHeight, MapConstants.GridWidth, MapConstants.GridHeight),
-                        Color.White,
-                        0f, 
-                        Vector2.Zero,
-                        SpriteEffects.None,
-                        LayerConstants.FogOfWarMapLayer
-                        
-                    );
-                    
-
-                    spriteBatch.FillRectangle(
-                        new Rectangle(
-                            i * MapConstants.GridWidth, 
-                            j * MapConstants.GridHeight,
-                            MapConstants.GridWidth,
-                            MapConstants.GridHeight),
-                        new Color(Color.Black, .5f),
-                        0,
-                        LayerConstants.FogOfWarLayer);
-                        
-                }
-
+                spriteBatch.DrawCircle(revealing.Center, revealing.RevelationRadius, 100, Color.Transparent, revealing.RevelationRadius);
             }
+
+            spriteBatch.End();
+
+        }
+
+        /// <summary>
+        /// Fills the inverted masks with a semi transparent color to make the illusion of fog of war
+        /// </summary>
+        /// <param name="spriteBatch"></param>
+        public void FillInvertedMask(SpriteBatch spriteBatch)
+        {
+            spriteBatch.Begin(SpriteSortMode.FrontToBack, BlendState.AlphaBlend, null, mApplyInvertedMaskStencilState, null, null, mCamera.GetTransform());
+
+            spriteBatch.FillRectangle(new Rectangle(0, 0, MapConstants.MapWidth, MapConstants.MapHeight), new Color(Color.Black, 0.5f));
+
+            spriteBatch.End();
         }
 
         /// <summary>
@@ -118,39 +169,13 @@ namespace Singularity.Map
 
         public void Update(GameTime gametime)
         {
-            // this is definitely not the best solution, the reason for this is that we dont want
-            // revealed portions to be revealed forever. So we need to set everything to false again before we reupdate the array.
-            mToDraw = new bool[
-                (MapConstants.MapWidth / MapConstants.GridWidth),
-                (MapConstants.MapHeight / MapConstants.GridHeight)
-            ];
+            mAlphaComparator.Projection = mCamera.GetStencilProjection();
+        }
 
-            foreach (var revealingObject in mRevealingObjects)
-            {
-                // first, we check every tile candidate which could be in the inner of the circle presented by the revealing object,
-                // where (x, y) is the center point of each tile.
-                for (var x = revealingObject.Center.X - revealingObject.RevelationRadius;
-                    x <= revealingObject.Center.X + revealingObject.RevelationRadius;
-                    x += MapConstants.GridWidth)
-                {
-                    for (var y = revealingObject.Center.Y - revealingObject.RevelationRadius;
-                        y <= revealingObject.Center.Y + revealingObject.RevelationRadius;
-                        y += MapConstants.GridHeight)
-                    {
-                        // Now we check whether the distance of the current point to the center of the circle is smaller than the radius of the circle
-                        // if yes -> point is in the circle, if no -> point is out of the circle
-                        if (Math.Sqrt(Math.Pow(x - revealingObject.Center.X, 2) +
-                                      Math.Pow(y - revealingObject.Center.Y, 2)) > revealingObject.RevelationRadius ||
-                            x > MapConstants.MapWidth || x < 0 || y > MapConstants.MapHeight || y < 0)
-                        {
-                            continue;
-                        }
-
-                        mToDraw[(int) (x / MapConstants.GridWidth), (int) (y / MapConstants.GridHeight)] = true;
-
-                    }
-                }
-            }
+        public DepthStencilState GetApplyMaskStencilState()
+        {
+            return mApplyMaskStencilState;
         }
     }
 }
+

--- a/Singularity/Singularity/Map/Map.cs
+++ b/Singularity/Singularity/Map/Map.cs
@@ -36,13 +36,8 @@ namespace Singularity.Map
         /// <param name="debug">Whether the debug grid lines are drawn or not</param>
         /// <param name="initialResources">The initial resources of this map, if not specified there will not be any on the map</param>
         /// <param name="fow">The fog of war for this map</param>
-        public Map(Texture2D backgroundTexture, Viewport viewport, FogOfWar fow, InputManager inputManager, bool debug = false, IDictionary<Vector2, Pair<EResourceType, int>> initialResources = null)
+        public Map(Texture2D backgroundTexture, Viewport viewport, InputManager inputManager, bool debug = false, IDictionary<Vector2, Pair<EResourceType, int>> initialResources = null)
         {
-            if (backgroundTexture.Width != MapConstants.MapWidth && backgroundTexture.Height != MapConstants.MapHeight)
-            {
-                // i'm limited to the options i'm given. This needs to be done so i can achieve consistency with the fog of war
-                throw new UnsupportedTextureSizeException(backgroundTexture.Width, backgroundTexture.Height, MapConstants.MapWidth, MapConstants.MapHeight);
-            }
 
             mBackgroundTexture = backgroundTexture;
             mDebug = debug;
@@ -50,7 +45,7 @@ namespace Singularity.Map
             mCamera = new Camera(viewport, inputManager, 0, 0);
 
             mCollisionMap = new CollisionMap();
-            mStructureMap = new StructureMap(fow);
+            mStructureMap = new StructureMap();
             mResourceMap = new ResourceMap(initialResources);
         }
 

--- a/Singularity/Singularity/Map/StructureMap.cs
+++ b/Singularity/Singularity/Map/StructureMap.cs
@@ -22,16 +22,11 @@ namespace Singularity.Map
         /// </summary>
         private readonly LinkedList<Pair<PlatformBlank, PlatformBlank>> mRoads;
 
-
-        private readonly FogOfWar mFow;
-
         /// <summary>
         /// Creates a new structure map which holds all the structures currently in the game.
         /// </summary>
-        public StructureMap(FogOfWar fow)
-        {
-            mFow = fow;
-
+        public StructureMap()
+        { 
             mPlatforms = new LinkedList<PlatformBlank>();
             mRoads = new LinkedList<Pair<PlatformBlank, PlatformBlank>>();
         }
@@ -43,7 +38,6 @@ namespace Singularity.Map
         public void AddPlatform(PlatformBlank platform)
         {
             mPlatforms.AddLast(platform);
-            mFow.AddRevealingObject(platform);
         }
 
         /// <summary>
@@ -53,7 +47,6 @@ namespace Singularity.Map
         public void RemovePlatform(PlatformBlank platform)
         {
             mPlatforms.Remove(platform);
-            mFow.RemoveRevealingObject(platform);
         }
 
         public LinkedList<PlatformBlank> GetPlatforms()

--- a/Singularity/Singularity/Platform/Road.cs
+++ b/Singularity/Singularity/Platform/Road.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.Xna.Framework;
+﻿using System;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Singularity.Libraries;
 using Singularity.Property;
 
 namespace Singularity.Platform
 {
-    internal sealed class Road : IDraw, ISpatial
+    internal sealed class Road : ISpatial
     {
         private Vector2 Source { get; }
         private Vector2 Destination { get; }
@@ -55,6 +56,11 @@ namespace Singularity.Platform
         public void Draw(SpriteBatch spriteBatch)
         {
             spriteBatch.DrawLine(Source, Destination, mBlueprint ? new Color(new Vector3(46, 53, 97)) : new Color(new Vector4(0, 40, 40, 255)), 5f, LayerConstants.RoadLayer);
+        }
+
+        public void Update(GameTime gametime)
+        {
+
         }
     }
 }

--- a/Singularity/Singularity/Property/ISpatial.cs
+++ b/Singularity/Singularity/Property/ISpatial.cs
@@ -10,7 +10,7 @@ namespace Singularity.Property
     /// thus store the "actual position on the current screen in relation to the camera". Those
     /// should be used when checking for the current position of this object.
     /// </summary>
-    internal interface ISpatial
+    internal interface ISpatial : IDraw, IUpdate
     {
         /// <summary>
         /// The relative position of this object. Relative to the camera that is. These

--- a/Singularity/Singularity/Resources/Resource.cs
+++ b/Singularity/Singularity/Resources/Resource.cs
@@ -12,42 +12,25 @@ namespace Singularity.Resources
     /// <summary>
     /// Represents a resource in the game. Written in such a fashion that it can represent any resource there is and will be.
     /// </summary>
-    public sealed class Resource : IResource
+    public sealed class Resource : ISpatial
     {
-
-        public const int DefaultWidth = 200;
-
-        /// <summary>
-        /// The current position of this resource on the map.
-        /// </summary>
-        private Vector2 mPosition;
 
         /// <summary>
         /// The color of this resource.
         /// </summary>
         private readonly Color mColor;
 
-
-        //TODO: remove when ISpatial is there. 
-
-        /// <summary>
-        /// The width of this resource. The height gets set by this value.
-        /// </summary>
-        private int mWidth;
-
-        /// <summary>
-        /// The height of this resource. Gets automatically set by the width.
-        /// </summary>
-        private int mHeight;
-
-        /*
-           TODO: im not quite sure whether the ID is "unique" such that every instance of this class
-           TODO: should hold a different id, or if every different resouce should hold a different id,
-           TODO: thus i've not written any id assignment yet.
-        */
-        public int Id { get; }
-
         public EResourceType Type { get; }
+
+        public Vector2 RelativePosition { get; set; }
+
+        public Vector2 RelativeSize { get; set; }
+        
+
+        public Vector2 AbsolutePosition { get; set; }
+        
+
+        public Vector2 AbsoluteSize { get; set; }
 
         /// <summary>
         /// Creates a new resource object for the given type, position and spriteSheet.
@@ -58,36 +41,17 @@ namespace Singularity.Resources
         public Resource(EResourceType type, Vector2 position, int width)
         {
             Type = type;
-            mPosition = position;
+
+            AbsolutePosition = position;
+            AbsoluteSize = new Vector2(width, (int)(width * 0.6f));
 
             mColor = ResourceHelper.GetColor(type);
 
-            // could be handled more dynamically, for now this is o.k.
-            mHeight = (int) (width * 0.6f);
-
-            mWidth = width;
-
-            if (width <= 0)
-            {
-                mWidth = DefaultWidth;
-            }
-
-        }
-
-        public void Follow(GeneralUnit unitToFollow)
-        {
-            //TODO: implement
-            throw new NotImplementedException();
         }
 
         public void Draw(SpriteBatch spriteBatch)
         {
-            spriteBatch.DrawEllipse(new Rectangle((int) mPosition.X, (int) mPosition.Y, mWidth, mHeight), mColor, 4f, LayerConstants.ResourceLayer);
-        }
-
-        public Vector2 GetPosition()
-        {
-            return mPosition;
+            spriteBatch.DrawEllipse(new Rectangle((int)AbsolutePosition.X, (int)AbsolutePosition.Y, (int)AbsoluteSize.X, (int)AbsoluteSize.Y), mColor, 4f, LayerConstants.ResourceLayer);
         }
 
         public void Update(GameTime gametime)
@@ -95,9 +59,5 @@ namespace Singularity.Resources
             //TODO: implement update code
         }
 
-        public void Use()
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/Singularity/Singularity/Screen/ScreenClasses/GameScreen.cs
+++ b/Singularity/Singularity/Screen/ScreenClasses/GameScreen.cs
@@ -1,10 +1,13 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO.MemoryMappedFiles;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using Singularity.Input;
+using Singularity.Libraries;
 using Singularity.Map;
+using Singularity.Map.Properties;
 using Singularity.Platform;
 using Singularity.Property;
 using Singularity.Resources;
@@ -40,7 +43,7 @@ namespace Singularity.Screen.ScreenClasses
 
         // input manager and viewport
         private readonly InputManager mInputManager;
-        private readonly Viewport mViewport;
+        private readonly GraphicsDevice mGraphicsDevice;
 
         // roads
         private Road mRoad1;
@@ -56,21 +59,33 @@ namespace Singularity.Screen.ScreenClasses
         private readonly LinkedList<IUpdate> mUpdateables;
 
         /// <summary>
+        /// The idea is that all spatial objects are affected by the fog of war, so we save them seperately to have a seperation
+        /// in our game screen. This way we can apply masks and all that stuff more easily.
+        /// </summary>
+        private readonly LinkedList<ISpatial> mSpatialObjects;
+
+        /// <summary>
         /// The camera object which holds transformation values.
         /// </summary>
         private Camera mCamera;
 
-        public GameScreen(Viewport viewport, InputManager inputManager)
+
+        public GameScreen(GraphicsDevice graphicsDevice, InputManager inputManager)
         {
+            mGraphicsDevice = graphicsDevice;
+
             mDrawables = new LinkedList<IDraw>();
             mUpdateables = new LinkedList<IUpdate>();
+            mSpatialObjects = new LinkedList<ISpatial>();
 
             mInputManager = inputManager;
-            mViewport = viewport;
         }
 
         public void Draw(SpriteBatch spriteBatch)
         {
+
+            // if you're interested in whats going on here, refer to the documentation of the FogOfWar class. 
+
             spriteBatch.Begin(SpriteSortMode.FrontToBack, BlendState.AlphaBlend, null, null, null, null, mCamera.GetTransform());
 
             foreach (var drawable in mDrawables)
@@ -79,6 +94,19 @@ namespace Singularity.Screen.ScreenClasses
             }
 
             spriteBatch.End();
+
+            mFow.DrawMasks(spriteBatch);
+
+            spriteBatch.Begin(SpriteSortMode.FrontToBack, BlendState.AlphaBlend, null, mFow.GetApplyMaskStencilState(), null, null, mCamera.GetTransform());
+
+            foreach (var spatial in mSpatialObjects)
+            {
+                spatial.Draw(spriteBatch);
+            }
+            spriteBatch.End();
+
+            mFow.FillInvertedMask(spriteBatch);
+           
 
         }
 
@@ -91,24 +119,28 @@ namespace Singularity.Screen.ScreenClasses
         {
             foreach (var updateable in mUpdateables)
             {
-                var spatial = updateable as ISpatial;
-
-                if (spatial != null)
-                {
-                    spatial.RelativePosition = Vector2.Transform(spatial.AbsolutePosition, mCamera.GetTransform());
-                    spatial.RelativeSize = spatial.AbsoluteSize * mCamera.GetZoom();
-
-
-                }
                 updateable.Update(gametime);
 
             }
+
+            foreach (var spatial in mSpatialObjects)
+            {
+
+                spatial.RelativePosition = Vector2.Transform(spatial.AbsolutePosition, mCamera.GetTransform());
+                spatial.RelativeSize = spatial.AbsoluteSize * mCamera.GetZoom();
+
+                spatial.Update(gametime);
+            }
+
+            mFow.Update(gametime);
+
+
         }
 
         public void LoadContent(ContentManager content)
         {
-            var mapBackground = content.Load<Texture2D>("MockUpBackground");
 
+            var mapBackground = content.Load<Texture2D>("MockUpBackground");
 
             mMUnitSheet = content.Load<Texture2D>("UnitSpriteSheet");
 
@@ -122,9 +154,12 @@ namespace Singularity.Screen.ScreenClasses
             mPlatform2 = new Junkyard(new Vector2(800, 600), mPlatformDomeTexture);
             mPlatform3 = new EnergyFacility(new Vector2(600, 200), mPlatformDomeTexture);
 
-            mFow = new FogOfWar(mapBackground);
-            mMap = new Map.Map(mapBackground, mViewport, mFow, mInputManager);
+
+            mMap = new Map.Map(mapBackground, mGraphicsDevice.Viewport, mInputManager);
             mCamera = mMap.GetCamera();
+
+            mFow = new FogOfWar(mCamera, mGraphicsDevice);
+
             AddObject(mMap);
 
             mMUnit1 = new MilitaryUnit(new Vector2(600, 600), mMUnitSheet, mMap.GetCamera(), mInputManager);
@@ -132,6 +167,9 @@ namespace Singularity.Screen.ScreenClasses
 
             mFow.AddRevealingObject(mMUnit1);
             mFow.AddRevealingObject(mMUnit2);
+            mFow.AddRevealingObject(mPlatform);
+            mFow.AddRevealingObject(mPlatform2);
+            mFow.AddRevealingObject(mPlatform3);
 
             mMap.AddPlatform(mPlatform);
             mMap.AddPlatform(mPlatform2);
@@ -150,8 +188,7 @@ namespace Singularity.Screen.ScreenClasses
             AddObject(mRoad1);
             AddObject(road2);
             AddObject(road3);
-            AddObject(mFow);
-            AddObject(ResourceHelper.GetRandomlyDistributedResources(5));
+            AddObjects(ResourceHelper.GetRandomlyDistributedResources(5));
 
             // artificially adding wait to test loading screen
             System.Threading.Thread.Sleep(500);
@@ -170,9 +207,16 @@ namespace Singularity.Screen.ScreenClasses
         /// <returns>True if the given object could be added, false otherwise</returns>
         public bool AddObject<T>(T toAdd)
         {
+
             if (!typeof(IDraw).IsAssignableFrom(typeof(T)) && !typeof(IUpdate).IsAssignableFrom(typeof(T)))
             {
                 return false;
+            }
+
+            if (typeof(ISpatial).IsAssignableFrom(typeof(T)))
+            {
+                mSpatialObjects.AddLast((ISpatial) toAdd);
+                return true;
             }
 
             if (typeof(IDraw).IsAssignableFrom(typeof(T)))
@@ -185,6 +229,25 @@ namespace Singularity.Screen.ScreenClasses
             }
             return true;
 
+        }
+
+        /// <summary>
+        /// Adds the given objects to the game screens list of objects to handle.
+        /// </summary>
+        /// <typeparam name="T">The type of the objects to be added. Needs to inherit from IDraw or IUpdate</typeparam>
+        /// <param name="toAdd">The objects to be added to the game screen</param>
+        /// <returns>True if all given objects could be added to the screen, false otherwise</returns>
+        public bool AddObjects<T>(IEnumerable<T> toAdd)
+        {
+            var isSuccessful = true;
+   
+            foreach (var t in toAdd)
+            {
+                isSuccessful = isSuccessful && AddObject<T>(t);
+            }
+   
+            return isSuccessful;
+   
         }
 
         /// <summary>

--- a/Singularity/Singularity/Units/MilitaryUnit.cs
+++ b/Singularity/Singularity/Units/MilitaryUnit.cs
@@ -170,6 +170,7 @@ namespace Singularity.Units
 
         public void Update(GameTime gameTime)
         {
+
             //make sure to update the relative bounds rectangle enclosing this unit.
             Bounds = new Rectangle(
                 (int)RelativePosition.X, (int)RelativePosition.Y, (int)RelativeSize.X, (int)RelativeSize.Y);


### PR DESCRIPTION
- The fog of war now is as dense as the circle in the Primitves2D library (currently with sides = 100)

- The fog of war is now way more performant, using stencil buffer as opposed to traversing every tile on the screen and re drawing the map for that tile.

- For explanation refer to the documentation in the fog of war class