### PR TITLE
#228 improved bounding boxes for platforms

### DIFF
--- a/Singularity/Singularity/Levels/Tutorial.cs
+++ b/Singularity/Singularity/Levels/Tutorial.cs
@@ -48,7 +48,7 @@ namespace Singularity.Levels
             var mapBackground = content.Load<Texture2D>("backgroundGrid");
 
             //Map related stuff
-            mMap = new Map.Map(mapBackground, 20, 20, mGraphics.Viewport, ref mDirector, true);
+            mMap = new Map.Map(mapBackground, 20, 20, mGraphics.Viewport, ref mDirector);
             mCamera = mMap.GetCamera();
             mFow = new FogOfWar(mCamera, mGraphics);
 

--- a/Singularity/Singularity/Map/Camera.cs
+++ b/Singularity/Singularity/Map/Camera.cs
@@ -11,7 +11,10 @@ using Singularity.Screen;
 namespace Singularity.Map
 {
     //TODO: update in such a way that zoom is centered on the current mouse position
-    /// <inheritdoc/>
+    /// <inheritdoc cref="IUpdate"/>
+    /// <inheritdoc cref="IKeyListener"/>
+    /// <inheritdoc cref="IMouseWheelListener"/>
+    /// <inheritdoc cref="IMousePositionListener"/>
     /// <remarks>
     /// The camera object is used to move and zoom the map and all its components.
     /// </remarks>

--- a/Singularity/Singularity/Map/CollisionMap.cs
+++ b/Singularity/Singularity/Map/CollisionMap.cs
@@ -47,10 +47,9 @@ namespace Singularity.Map
                 mGridXLength,
                 mGridYLength
             ];
-            bool[][] movableMatrix = new bool[mGridXLength][];
 
-
-
+            // movableMatrix is used to construct a StaticGrid object, which is used by the pathfinder.
+            var movableMatrix = new bool[mGridXLength][];
 
             for (var i = 0; i < mCollisionMap.GetLength(0); i++)
             {
@@ -70,10 +69,9 @@ namespace Singularity.Map
         /// Updates the collision map for the given coordinates and id. If the object identified by the id is already present
         /// in the collision map the coordinates get updated, otherwise it gets added.
         /// </summary>
-        /// <param name="collider">The collider to be updated updated</param>
+        /// <param name="collider">The collider to be updated.</param>
         public void UpdateCollider(ICollider collider)
         {
-
             //Check if the location of an already existing collider needs to be updated.
             if (mLookUpTable.ContainsKey(collider.Id) && collider.Moved)
             {
@@ -85,20 +83,32 @@ namespace Singularity.Map
                     {
                         mCollisionMap[x, y] = new CollisionNode(x, y, Optional<ICollider>.Of(null));
                         mWalkableGrid.SetWalkableAt(x, y, true);
-
                     }
                 }
             }
 
             //add the given collider to the collision map.
-
-            for (var x = collider.AbsBounds.X / MapConstants.GridWidth; x <= (collider.AbsBounds.X + collider.AbsBounds.Width) / MapConstants.GridWidth; x++)
+            var i = 0;
+            var j = 0;
+            for (var x = collider.AbsBounds.X / MapConstants.GridWidth; x < (collider.AbsBounds.X + collider.AbsBounds.Width) / MapConstants.GridWidth; x++)
             {
-                for (var y = (collider.AbsBounds.Y / MapConstants.GridHeight); y <= ((collider.AbsBounds.Y + collider.AbsBounds.Height) / MapConstants.GridHeight) ; y++)
+                for (var y = (collider.AbsBounds.Y / MapConstants.GridHeight); y < ((collider.AbsBounds.Y + collider.AbsBounds.Height) / MapConstants.GridHeight) ; y++)
                 {
-                    mCollisionMap[x, y] = new CollisionNode(x, y, Optional<ICollider>.Of(collider));Optional<ICollider>.Of(collider);
-                    mWalkableGrid.SetWalkableAt(x, y, false);
+                    
+                    Debug.WriteLine("i, j: " + i + ", " + j);
+                    /*
+                    if (collider.ColliderGrid != null && collider.ColliderGrid[j, i] && false)
+                    {
+                        mCollisionMap[x, y] = new CollisionNode(x, y, Optional<ICollider>.Of(collider));
+                        Optional<ICollider>.Of(collider);
+                        mWalkableGrid.SetWalkableAt(x, y, false);
+                    }
+                    */
+
+                    j++;
                 }
+
+                i++;
             }
 
             mLookUpTable[collider.Id] = collider.AbsBounds;

--- a/Singularity/Singularity/Map/CollisionMap.cs
+++ b/Singularity/Singularity/Map/CollisionMap.cs
@@ -14,9 +14,6 @@ namespace Singularity.Map
     /// </summary>
     internal sealed class CollisionMap
     {
-        // Number of cells in the grid
-        private readonly int mGridXLength;
-        private readonly int mGridYLength;
         /// <summary>
         /// The look up table is used to check whether a given collider is already present in the collision map
         /// </summary>
@@ -39,21 +36,21 @@ namespace Singularity.Map
         {
             mLookUpTable = new Dictionary<int, Rectangle>();
 
-            mGridXLength = MapConstants.MapWidth / MapConstants.GridWidth;
-            mGridYLength = MapConstants.MapHeight / MapConstants.GridHeight;
+            var GridXLength = MapConstants.MapWidth / MapConstants.GridWidth;
+            var GridYLength = MapConstants.MapHeight / MapConstants.GridHeight;
 
             mCollisionMap = new CollisionNode
             [
-                mGridXLength,
-                mGridYLength
+                GridXLength,
+                GridYLength
             ];
 
             // movableMatrix is used to construct a StaticGrid object, which is used by the pathfinder.
-            var movableMatrix = new bool[mGridXLength][];
+            var movableMatrix = new bool[GridXLength][];
 
             for (var i = 0; i < mCollisionMap.GetLength(0); i++)
             {
-                movableMatrix[i] = new bool[mGridYLength];
+                movableMatrix[i] = new bool[GridYLength];
 
                 for (var j = 0; j < mCollisionMap.GetLength(1); j++)
                 {
@@ -61,7 +58,7 @@ namespace Singularity.Map
                     movableMatrix[i][j] = Map.IsOnTop(new Vector2(i * MapConstants.GridWidth, j * MapConstants.GridHeight));
                 }
             }
-            mWalkableGrid = new StaticGrid(mGridXLength, mGridYLength, movableMatrix);
+            mWalkableGrid = new StaticGrid(GridXLength, GridYLength, movableMatrix);
 
         }
 

--- a/Singularity/Singularity/Map/CollisionMap.cs
+++ b/Singularity/Singularity/Map/CollisionMap.cs
@@ -87,28 +87,26 @@ namespace Singularity.Map
                 }
             }
 
-            //add the given collider to the collision map.
-            var i = 0;
-            var j = 0;
-            for (var x = collider.AbsBounds.X / MapConstants.GridWidth; x < (collider.AbsBounds.X + collider.AbsBounds.Width) / MapConstants.GridWidth; x++)
+            if (collider.ColliderGrid == null)
             {
-                for (var y = (collider.AbsBounds.Y / MapConstants.GridHeight); y < ((collider.AbsBounds.Y + collider.AbsBounds.Height) / MapConstants.GridHeight) ; y++)
+                return;
+            }
+            //add the given collider to the collision map.
+            for (var i = 0; i < collider.ColliderGrid.GetLength(1); i++)
+            {
+                for (var j = 0; j < collider.ColliderGrid.GetLength(0); j++)
                 {
-                    
-                    Debug.WriteLine("i, j: " + i + ", " + j);
-                    /*
-                    if (collider.ColliderGrid != null && collider.ColliderGrid[j, i] && false)
+                    if (!collider.ColliderGrid[j, i])
                     {
-                        mCollisionMap[x, y] = new CollisionNode(x, y, Optional<ICollider>.Of(collider));
-                        Optional<ICollider>.Of(collider);
-                        mWalkableGrid.SetWalkableAt(x, y, false);
+                        continue;
                     }
-                    */
 
-                    j++;
+                    var x = (int) (collider.AbsolutePosition.X / MapConstants.GridWidth) + i;
+                    var y = (int) (collider.AbsolutePosition.Y / MapConstants.GridHeight) + j;
+                    mCollisionMap[x, y] = new CollisionNode(x, y, Optional<ICollider>.Of(collider));
+                    Optional<ICollider>.Of(collider);
+                    mWalkableGrid.SetWalkableAt(x, y, false);
                 }
-
-                i++;
             }
 
             mLookUpTable[collider.Id] = collider.AbsBounds;

--- a/Singularity/Singularity/Map/Map.cs
+++ b/Singularity/Singularity/Map/Map.cs
@@ -48,7 +48,6 @@ namespace Singularity.Map
             int height,
             Viewport viewport,
             ref Director director,
-            bool debug = false,
             IEnumerable<MapResource> initialResources = null,
             bool neo = false)
         {
@@ -56,7 +55,7 @@ namespace Singularity.Map
             mHeight = height;
 
             mBackgroundTexture = backgroundTexture;
-            mDebug = debug;
+            mDebug = GlobalVariables.DebugState;
 
 
             mCamera = new Camera(viewport, ref director, 800, 800, neo);
@@ -318,6 +317,7 @@ namespace Singularity.Map
             {
                 if (key == Keys.F4)
                 {
+                    GlobalVariables.DebugState = !GlobalVariables.DebugState;
                     mDebug = !mDebug;
                 }
             }

--- a/Singularity/Singularity/Platform/CommandCenter.cs
+++ b/Singularity/Singularity/Platform/CommandCenter.cs
@@ -34,7 +34,7 @@ namespace Singularity.Platform
             mCost = new Dictionary<EResourceType, int>();
             mType = EPlatformType.Command;
             mSpritename = "Cylinders";
-            AbsoluteSize = SetPlatfromDrawParameters();
+            SetPlatfromParameters();
             mControlledUnits = new List<GeneralUnit>();
             dir.GetStoryManager.AddEnergy(5);
         }

--- a/Singularity/Singularity/Platform/EnergyFacility.cs
+++ b/Singularity/Singularity/Platform/EnergyFacility.cs
@@ -25,7 +25,7 @@ namespace Singularity.Platform
             mCost = new Dictionary<EResourceType, int>();
             mType = EPlatformType.Energy;
             mSpritename = "Dome";
-            AbsoluteSize = SetPlatfromDrawParameters();
+            SetPlatfromParameters();
         }
 
         public void TurnOn(Manager.StoryManager story)

--- a/Singularity/Singularity/Platform/Factory.cs
+++ b/Singularity/Singularity/Platform/Factory.cs
@@ -29,7 +29,7 @@ namespace Singularity.Platform
             mCost = new Dictionary<EResourceType, int>();
             mType = EPlatformType.Factory;
             mSpritename = "Dome";
-            AbsoluteSize = SetPlatfromDrawParameters();
+            SetPlatfromParameters();
         }
 
         public override void Produce()

--- a/Singularity/Singularity/Platform/Junkyard.cs
+++ b/Singularity/Singularity/Platform/Junkyard.cs
@@ -27,7 +27,7 @@ namespace Singularity.Platform
             mCost = new Dictionary<EResourceType, int>();
             mType = EPlatformType.Junkyard;
             mSpritename = "Dome";
-            AbsoluteSize = SetPlatfromDrawParameters();
+            SetPlatfromParameters();
         }
 
         public void BurnTrash()

--- a/Singularity/Singularity/Platform/Mine.cs
+++ b/Singularity/Singularity/Platform/Mine.cs
@@ -31,7 +31,7 @@ namespace Singularity.Platform
             mCost = new Dictionary<EResourceType, int>();
             mType = EPlatformType.Mine;
             mSpritename = "Dome";
-            AbsoluteSize = SetPlatfromDrawParameters();
+            SetPlatfromParameters();
         }
 
         public void Produce()

--- a/Singularity/Singularity/Platform/PlatformBlank.cs
+++ b/Singularity/Singularity/Platform/PlatformBlank.cs
@@ -612,12 +612,12 @@ namespace Singularity.Platform
                     AbsoluteSize = new Vector2(148, 85);
                     ColliderGrid = new [,]
                     {
-                        { false, true,  true,  true,  true,  true,  true,  false, false },
-                        { true,  true,  true,  true,  true,  true,  true,  true , false },
-                        { true,  true,  true,  true,  true,  true,  true,  true , false },
-                        { true,  true,  true,  true,  true,  true,  true,  false, false },
-                        { false, false, true,  true,  true,  true,  false, false, false },
-                        { false, false, false, false, false, false, false, false, false }
+                        { false, true,  true,  true,  true,  true,  true,  false },
+                        { true,  true,  true,  true,  true,  true,  true,  true  },
+                        { true,  true,  true,  true,  true,  true,  true,  true  },
+                        { true,  true,  true,  true,  true,  true,  true,  false },
+                        { false, false, true,  true,  true,  true,  false, false },
+                        { false, false, false, false, false, false, false, false }
                     };
                     break;
                 case (1):
@@ -625,16 +625,16 @@ namespace Singularity.Platform
                     AbsoluteSize = new Vector2(148, 165);
                     ColliderGrid = new [,]
                     {
-                        { false, false, false, false, false, false, false, false, false },
-                        { false, false, false, false, false, false, false, false, false },
-                        { false, false, false, false, false, false, false, false, false },
-                        { false, false, false, false, false, false, false, false, false },
-                        { false, true,  true,  true,  true,  true,  true,  false, false },
-                        { true,  true,  true,  true,  true,  true,  true,  true , false },
-                        { true,  true,  true,  true,  true,  true,  true,  true , false },
-                        { true,  true,  true,  true,  true,  true,  true,  false, false },
-                        { false, false, true,  true,  true,  true,  false, false, false },
-                        { false, false, false, false, false, false, false, false, false }
+                        { false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false },
+                        { false, true,  true,  true,  true,  true,  true,  false },
+                        { true,  true,  true,  true,  true,  true,  true,  true  },
+                        { true,  true,  true,  true,  true,  true,  true,  true  },
+                        { true,  true,  true,  true,  true,  true,  true,  false },
+                        { false, false, true,  true,  true,  true,  false, false },
+                        { false, false, false, false, false, false, false, false }
                     };
                     break;
                 case (2):
@@ -642,16 +642,16 @@ namespace Singularity.Platform
                     AbsoluteSize = new Vector2(148, 170);
                     ColliderGrid = new [,]
                     {
-                        { false, false, false, false, false, false, false, false, false },
-                        { false, false, false, false, false, false, false, false, false },
-                        { false, false, false, false, false, false, false, false, false },
-                        { false, false, false, false, false, false, false, false, false },
-                        { false, true,  true,  true,  true,  true,  true,  false, false },
-                        { true,  true,  true,  true,  true,  true,  true,  true , false },
-                        { true,  true,  true,  true,  true,  true,  true,  true , false },
-                        { true,  true,  true,  true,  true,  true,  true,  false, false },
-                        { false, false, true,  true,  true,  true,  false, false, false },
-                        { false, false, false, false, false, false, false, false, false }
+                        { false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false },
+                        { false, true,  true,  true,  true,  true,  true,  false },
+                        { true,  true,  true,  true,  true,  true,  true,  true  },
+                        { true,  true,  true,  true,  true,  true,  true,  true  },
+                        { true,  true,  true,  true,  true,  true,  true,  false },
+                        { false, false, true,  true,  true,  true,  false, false },
+                        { false, false, false, false, false, false, false, false }
                     };
                     break;
                 case (3):
@@ -659,14 +659,14 @@ namespace Singularity.Platform
                     AbsoluteSize = new Vector2(148, 126);
                     ColliderGrid = new [,]
                     {
-                        { false, false, false, false, false, false, false, false, false },
-                        { false, false, false, false, false, false, false, false, false },
-                        { false, true,  true,  true,  true,  true,  true,  false, false },
-                        { true,  true,  true,  true,  true,  true,  true,  true , false },
-                        { true,  true,  true,  true,  true,  true,  true,  true , false },
-                        { true,  true,  true,  true,  true,  true,  true,  false, false },
-                        { false, false, true,  true,  true,  true,  false, false, false },
-                        { false, false, false, false, false, false, false, false, false }
+                        { false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false },
+                        { false, true,  true,  true,  true,  true,  true,  false },
+                        { true,  true,  true,  true,  true,  true,  true,  true  },
+                        { true,  true,  true,  true,  true,  true,  true,  true  },
+                        { true,  true,  true,  true,  true,  true,  true,  false },
+                        { false, false, true,  true,  true,  true,  false, false },
+                        { false, false, false, false, false, false, false, false }
                     };
                     break;
                 default:

--- a/Singularity/Singularity/Platform/PlatformBlank.cs
+++ b/Singularity/Singularity/Platform/PlatformBlank.cs
@@ -12,28 +12,54 @@ using Singularity.Utils;
 
 namespace Singularity.Platform
 {
+    /// <inheritdoc cref="IRevealing"/>
+    /// <inheritdoc cref="INode"/>
+    /// <inheritdoc cref="ICollider"/>
     [DataContract]
     public class PlatformBlank : IRevealing, INode, ICollider
 
     {
-
+        /// <summary>
+        /// List of inwards facing edges/roads towards the platform.
+        /// </summary>
         private List<IEdge> mInwardsEdges;
 
+        /// <summary>
+        /// List of outwards facing edges/roads.
+        /// </summary>
         private List<IEdge> mOutwardsEdges;
 
+        /// <summary>
+        /// Indicates the type of platform this is, defaults to blank.
+        /// </summary>
         [DataMember]
         internal EPlatformType mType = EPlatformType.Blank;
 
+        /// <summary>
+        /// Indicates the platform width
+        /// </summary>
         [DataMember]
         private const int PlatformWidth = 148;
+
+        /// <summary>
+        /// Indicates the platform height.
+        /// </summary>
         [DataMember]
         private const int PlatformHeight = 172;
+
+        /// <summary>
+        /// How much health the platform has
+        /// </summary>
         [DataMember]
         private int mHealth;
-        [DataMember]
-        private int mId;
+
+        /// <summary>
+        /// Indicates if the platform is a "real" platform or a blueprint.
+        /// </summary>
         [DataMember]
         protected bool mIsBlueprint;
+
+
         [DataMember]
         protected Dictionary<EResourceType, int> mCost;
         [DataMember]
@@ -79,6 +105,8 @@ namespace Singularity.Platform
         [DataMember]
         public Vector2 RelativeSize { get; set; }
 
+        public bool[,] ColliderGrid { get; internal set; }
+
 
         public PlatformBlank(Vector2 position, Texture2D platformSpriteSheet, Texture2D baseSprite, Vector2 center = new Vector2())
         {
@@ -86,8 +114,6 @@ namespace Singularity.Platform
             Id = IdGenerator.NextiD();
 
             mType = EPlatformType.Blank;
-
-            AbsoluteSize = SetPlatfromDrawParameters();
 
             mInwardsEdges = new List<IEdge>();
             mOutwardsEdges = new List<IEdge>();
@@ -129,8 +155,8 @@ namespace Singularity.Platform
                 Center = center;
             }
 
-            AbsoluteSize = SetPlatfromDrawParameters(); // this changes the draw parameters based on the platform type but
-                                                        // also returns the AbsoluteSize so the property can be set
+            SetPlatfromParameters(); // this changes the draw parameters based on the platform type but
+                                     // also sets the AbsoluteSize and collider grids
 
         }
 
@@ -470,7 +496,7 @@ namespace Singularity.Platform
         /// Sets all the parameters to draw a platfrom properly and calculates the absolute size of a platform.
         /// </summary>
         /// <returns>Absolute Size of a platform</returns>
-        protected Vector2 SetPlatfromDrawParameters()
+        protected void SetPlatfromParameters()
         {
             mSheetPosition = 0;
             switch (mType)
@@ -583,18 +609,69 @@ namespace Singularity.Platform
             {
                 case (0):
                     // basic platforms
-                    return new Vector2(148, 85);
+                    AbsoluteSize = new Vector2(148, 85);
+                    ColliderGrid = new [,]
+                    {
+                        { false, true,  true,  true,  true,  true,  true,  false, false },
+                        { true,  true,  true,  true,  true,  true,  true,  true , false },
+                        { true,  true,  true,  true,  true,  true,  true,  true , false },
+                        { true,  true,  true,  true,  true,  true,  true,  false, false },
+                        { false, false, true,  true,  true,  true,  false, false, false },
+                        { false, false, false, false, false, false, false, false, false }
+                    };
+                    break;
                 case (1):
                     // cones
-                    return new Vector2(148, 165);
+                    AbsoluteSize = new Vector2(148, 165);
+                    ColliderGrid = new [,]
+                    {
+                        { false, false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false, false },
+                        { false, true,  true,  true,  true,  true,  true,  false, false },
+                        { true,  true,  true,  true,  true,  true,  true,  true , false },
+                        { true,  true,  true,  true,  true,  true,  true,  true , false },
+                        { true,  true,  true,  true,  true,  true,  true,  false, false },
+                        { false, false, true,  true,  true,  true,  false, false, false },
+                        { false, false, false, false, false, false, false, false, false }
+                    };
+                    break;
                 case (2):
                     // cylinders
-                    return new Vector2(148, 170);
+                    AbsoluteSize = new Vector2(148, 170);
+                    ColliderGrid = new [,]
+                    {
+                        { false, false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false, false },
+                        { false, true,  true,  true,  true,  true,  true,  false, false },
+                        { true,  true,  true,  true,  true,  true,  true,  true , false },
+                        { true,  true,  true,  true,  true,  true,  true,  true , false },
+                        { true,  true,  true,  true,  true,  true,  true,  false, false },
+                        { false, false, true,  true,  true,  true,  false, false, false },
+                        { false, false, false, false, false, false, false, false, false }
+                    };
+                    break;
                 case (3):
                     // domes
-                    return new Vector2(148, 126);
+                    AbsoluteSize = new Vector2(148, 126);
+                    ColliderGrid = new [,]
+                    {
+                        { false, false, false, false, false, false, false, false, false },
+                        { false, false, false, false, false, false, false, false, false },
+                        { false, true,  true,  true,  true,  true,  true,  false, false },
+                        { true,  true,  true,  true,  true,  true,  true,  true , false },
+                        { true,  true,  true,  true,  true,  true,  true,  true , false },
+                        { true,  true,  true,  true,  true,  true,  true,  false, false },
+                        { false, false, true,  true,  true,  true,  false, false, false },
+                        { false, false, false, false, false, false, false, false, false }
+                    };
+                    break;
                 default:
-                    return Vector2.Zero;
+                    throw new ArgumentOutOfRangeException("Attempted to use a spritesheet "
+                        + "for platforms that doesn't exist.");
             }
         }
     }

--- a/Singularity/Singularity/Platform/Quarry.cs
+++ b/Singularity/Singularity/Platform/Quarry.cs
@@ -30,7 +30,7 @@ namespace Singularity.Platform
             mCost = new Dictionary<EResourceType, int>();
             mType = EPlatformType.Quarry;
             mSpritename = "Dome";
-            AbsoluteSize = SetPlatfromDrawParameters();
+            SetPlatfromParameters();
         }
 
         public void Produce()

--- a/Singularity/Singularity/Platform/Storage.cs
+++ b/Singularity/Singularity/Platform/Storage.cs
@@ -27,7 +27,7 @@ namespace Singularity.Platform
             mCost = new Dictionary<EResourceType, int>();
             mType = EPlatformType.Storage;
             mSpritename = "Dome";
-            AbsoluteSize = SetPlatfromDrawParameters();
+            SetPlatfromParameters();
         }
 
         /// <summary>

--- a/Singularity/Singularity/Platform/Well.cs
+++ b/Singularity/Singularity/Platform/Well.cs
@@ -31,7 +31,7 @@ namespace Singularity.Platform
             mCost = new Dictionary<EResourceType, int>();
             mType = EPlatformType.Well;
             mSpritename = "Dome";
-            AbsoluteSize = SetPlatfromDrawParameters();
+            SetPlatfromParameters();
         }
 
         public void Produce()

--- a/Singularity/Singularity/Property/GlobalVariables.cs
+++ b/Singularity/Singularity/Property/GlobalVariables.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Singularity.Property
+{
+    internal static class GlobalVariables
+    {
+        /// <summary>
+        /// Indicates whether the game is in debug mode or not
+        /// </summary>
+        internal static bool DebugState { get; set; } = true;
+
+    }
+}

--- a/Singularity/Singularity/Property/ICollider.cs
+++ b/Singularity/Singularity/Property/ICollider.cs
@@ -1,37 +1,22 @@
 ﻿using Microsoft.Xna.Framework;
-using Singularity.Map.Properties;
 
 namespace Singularity.Property
 {
     internal interface ICollider : ISpatial
     {
         /// <summary>
-        /// Creates a collider grid that shows for each grid point in the bounding
-        /// box if that grid position is collidable.
+        /// Provides a lookup table for which spaces have a collider in them and which don't within the bounding box
         /// </summary>
-        /// For example:
-        /// [0, 0, 0, 0, 0,
-        ///  0, 0, 1, 0, 0,
-        ///  0, 1, 1, 1, 0,
-        ///  0, 0, 1, 0, 0,]
-        ///
-        /// is the ColliderGrid for an  diamond shaped object.
         bool[,] ColliderGrid { get; }
 
         /// <summary>
-        /// Absolute bounding box of an object. The object MUST be smaller
-        /// than this bounding box.
+        /// Indicates the absolute bounds of a collider. The entire object must be within this bounds
         /// </summary>
         Rectangle AbsBounds { get; }
 
-        /// <summary>
-        /// Indicates if an object has moved since the last update call.
-        /// </summary>
+
         bool Moved { get; }
 
-        /// <summary>
-        /// Unique unit ID.
-        /// </summary>
         int Id { get; }
     }
 }

--- a/Singularity/Singularity/Property/ICollider.cs
+++ b/Singularity/Singularity/Property/ICollider.cs
@@ -1,13 +1,37 @@
 ﻿using Microsoft.Xna.Framework;
+using Singularity.Map.Properties;
 
 namespace Singularity.Property
 {
     internal interface ICollider : ISpatial
     {
+        /// <summary>
+        /// Creates a collider grid that shows for each grid point in the bounding
+        /// box if that grid position is collidable.
+        /// </summary>
+        /// For example:
+        /// [0, 0, 0, 0, 0,
+        ///  0, 0, 1, 0, 0,
+        ///  0, 1, 1, 1, 0,
+        ///  0, 0, 1, 0, 0,]
+        ///
+        /// is the ColliderGrid for an  diamond shaped object.
+        bool[,] ColliderGrid { get; }
+
+        /// <summary>
+        /// Absolute bounding box of an object. The object MUST be smaller
+        /// than this bounding box.
+        /// </summary>
         Rectangle AbsBounds { get; }
 
+        /// <summary>
+        /// Indicates if an object has moved since the last update call.
+        /// </summary>
         bool Moved { get; }
 
+        /// <summary>
+        /// Unique unit ID.
+        /// </summary>
         int Id { get; }
     }
 }

--- a/Singularity/Singularity/Singularity.csproj
+++ b/Singularity/Singularity/Singularity.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <Compile Include="Manager\DistributionManager.cs" />
     <Compile Include="Manager\MilitaryManager.cs" />
+    <Compile Include="Property\GlobalVariables.cs" />
     <Compile Include="Units\EnemyUnit.cs" />
     <Compile Include="Units\SelectionBox.cs" />
     <Compile Include="Units\Task.cs" />

--- a/Singularity/Singularity/Units/EnemyUnit.cs
+++ b/Singularity/Singularity/Units/EnemyUnit.cs
@@ -68,6 +68,8 @@ namespace Singularity.Units
 
         public Rectangle AbsBounds { get; private set; }
 
+        public bool[,] ColliderGrid { get; }
+
         public EnemyUnit(Vector2 position, Texture2D spriteSheet, Camera camera, ref Director director)
         {
             Id = IdGenerator.NextiD(); // TODO this will later use a random number generator to create a unique

--- a/Singularity/Singularity/Units/MilitaryPathfinder.cs
+++ b/Singularity/Singularity/Units/MilitaryPathfinder.cs
@@ -42,10 +42,12 @@ namespace Singularity.Units
             var pathGrid = JumpPointFinder.FindPath(mJpParam);
 
             var pathVector = new Stack<Vector2>(pathGrid.Count);
+
             pathVector.Push(endPosition);
+            
 
             Debug.WriteLine("Path:");
-            for (int i = pathGrid.Count - 1; i > 0; i--)
+            for (var i = pathGrid.Count - 1; i > 0; i--)
             {
                 var gridPos = GridPosToVector2(pathGrid[i]);
                 Debug.WriteLine(gridPos.X + ", " + gridPos.Y);

--- a/Singularity/Singularity/Units/MilitaryUnit.cs
+++ b/Singularity/Singularity/Units/MilitaryUnit.cs
@@ -85,6 +85,8 @@ namespace Singularity.Units
 
         public Rectangle AbsBounds { get; private set; }
 
+        public bool[,] ColliderGrid { get; }
+
         
         public MilitaryUnit(Vector2 position, Texture2D spriteSheet, Camera camera, ref Director director, ref Map.Map map)
         {

--- a/Singularity/Singularity/Units/MilitaryUnit.cs
+++ b/Singularity/Singularity/Units/MilitaryUnit.cs
@@ -8,6 +8,7 @@ using Singularity.Input;
 using Singularity.Libraries;
 using Singularity.Manager;
 using Singularity.Map;
+using Singularity.Map.Properties;
 using Singularity.Property;
 using Singularity.Screen;
 using Singularity.Sound;
@@ -340,28 +341,44 @@ namespace Singularity.Units
             switch (mouseAction)
             {
                 case EMouseAction.LeftClick:
-                    if (mSelected && !mIsMoving && !withinBounds && Map.Map.IsOnTop(new Rectangle((int)(mMouseX - RelativeSize.X / 2f), (int)(mMouseY - RelativeSize.Y / 2f), (int)RelativeSize.X, (int)RelativeSize.Y), mCamera))
+                    // check for if the unit is selected, not moving, the click is not within the bounds of the unit, and the click was on the map.
+                    if (mSelected
+                        && !mIsMoving
+                        && !withinBounds
+                        && Map.Map.IsOnTop(new Rectangle((int) (mMouseX - RelativeSize.X / 2f),
+                                (int) (mMouseY - RelativeSize.Y / 2f),
+                                (int) RelativeSize.X,
+                                (int) RelativeSize.Y),
+                            mCamera))
                     {
-                        mIsMoving = true;
+                        
                         mTargetPosition = Vector2.Transform(new Vector2(Mouse.GetState().X, Mouse.GetState().Y),
                             Matrix.Invert(mCamera.GetTransform()));
-                        var currentPosition = Center;
-                        Debug.WriteLine("Starting path finding at: " + currentPosition.X +", " + currentPosition.Y);
-                        Debug.WriteLine("Target: " + mTargetPosition.X + ", " + mTargetPosition.Y);
+                        if (mMap.GetCollisionMap().GetWalkabilityGrid().IsWalkableAt(
+                            (int) mTargetPosition.X / MapConstants.GridWidth,
+                            (int) mTargetPosition.Y / MapConstants.GridWidth))
+                        {
+                            mIsMoving = true;
 
-                        mPath = new Stack<Vector2>();
-                        mPath = mPathfinder.FindPath(currentPosition,
-                            mTargetPosition,
-                            ref mMap);
+                            var currentPosition = Center;
+                            Debug.WriteLine("Starting path finding at: " + currentPosition.X + ", " + currentPosition.Y);
+                            Debug.WriteLine("Target: " + mTargetPosition.X + ", " + mTargetPosition.Y);
 
-                        // TODO: DEBUG REGION
-                        mDebugPath = mPath.ToArray();
+                            mPath = new Stack<Vector2>();
+                            mPath = mPathfinder.FindPath(currentPosition,
+                                mTargetPosition,
+                                ref mMap);
 
-                        // TODO: END DEBUG REGION
+                            // TODO: DEBUG REGION
+                            mDebugPath = mPath.ToArray();
 
-                        mBoundsSnapshot = Bounds;
-                        mZoomSnapshot = mCamera.GetZoom();
-                        giveThrough = true;
+                            // TODO: END DEBUG REGION
+
+                            mBoundsSnapshot = Bounds;
+                            mZoomSnapshot = mCamera.GetZoom();
+                            giveThrough = true;
+                        }
+                        
                     }
 
                     if (withinBounds) {

--- a/Singularity/Singularity/Units/MilitaryUnit.cs
+++ b/Singularity/Singularity/Units/MilitaryUnit.cs
@@ -200,13 +200,16 @@ namespace Singularity.Units
                 SpriteEffects.None,
                 LayerConstants.MilitaryUnitLayer
                 );
-            
-            // TODO DEBUG REGION
-            if (mDebugPath != null)
+
+            if (GlobalVariables.DebugState)
             {
-                for (var i = 0; i < mDebugPath.Length - 1; i++)
+                // TODO DEBUG REGION
+                if (mDebugPath != null)
                 {
-                    spriteBatch.DrawLine(mDebugPath[i], mDebugPath[i + 1], Color.Orange);
+                    for (var i = 0; i < mDebugPath.Length - 1; i++)
+                    {
+                        spriteBatch.DrawLine(mDebugPath[i], mDebugPath[i + 1], Color.Orange);
+                    }
                 }
             }
 
@@ -369,10 +372,12 @@ namespace Singularity.Units
                                 mTargetPosition,
                                 ref mMap);
 
-                            // TODO: DEBUG REGION
-                            mDebugPath = mPath.ToArray();
-
-                            // TODO: END DEBUG REGION
+                            if (GlobalVariables.DebugState)
+                            {
+                                // TODO: DEBUG REGION
+                                mDebugPath = mPath.ToArray();
+                                // TODO: END DEBUG REGION
+                            }
 
                             mBoundsSnapshot = Bounds;
                             mZoomSnapshot = mCamera.GetZoom();


### PR DESCRIPTION
- Improved the way bounding boxes work for platforms by making them non-rectangular
- Removes ability to find path within an obstacle
- Creates a global debug variable that can be set so that debug info is only visible when F4 is pressed for all debug info, not just map (e.g. pathfinding debug)

closes #248, closes #228, closes #243, closes #247