### PR TITLE
Disable ui changes due to resolution changes

### DIFF
--- a/Singularity/Singularity/Screen/HorizontalCollection.cs
+++ b/Singularity/Singularity/Screen/HorizontalCollection.cs
@@ -89,7 +89,6 @@ namespace Singularity.Screen
                 foreach (var item in mItemList)
                 {
                     item.Draw(spriteBatch);
-                    System.Diagnostics.Debug.WriteLine(item.Position);
                 }
             }
         }

--- a/Singularity/Singularity/Screen/PopupWindow.cs
+++ b/Singularity/Singularity/Screen/PopupWindow.cs
@@ -5,7 +5,7 @@ using Singularity.Input;
 using Singularity.Libraries;
 using Singularity.Property;
 
-namespace Singularity.Screen.ScreenClasses
+namespace Singularity.Screen
 {
     internal sealed class PopupWindow : IDraw, IUpdate, IMouseWheelListener, IMousePositionListener
     {
@@ -13,7 +13,6 @@ namespace Singularity.Screen.ScreenClasses
         // parameters
         private readonly string mWindowName;
         private readonly Button mButton;
-        private readonly Vector2 mPosition;
         private readonly Vector2 mSize;
         private readonly Color mColorBorder;
         private readonly Color mColorFill;
@@ -70,7 +69,7 @@ namespace Singularity.Screen.ScreenClasses
             GraphicsDeviceManager graphics)
         {
             mWindowName = windowName;
-            mPosition = position;
+            Position = position;
             mSize = size;
             mColorBorder = colorBorder;
             mColorFill = colorFill;
@@ -87,48 +86,48 @@ namespace Singularity.Screen.ScreenClasses
             var buttonSize = new Vector2(button.Size.X + 10, button.Size.Y + 10);
 
             // position where the next item will be drawn
-            mItemPosTop = new Vector2(mPosition.X + 10, mPosition.Y + titleSizeY + 30); // TODO
+            mItemPosTop = new Vector2(Position.X + 10, Position.Y + titleSizeY + 30); // TODO
 
             // set the window rectangle
             mWindowRectangle = new Rectangle(
-                x: (int)(mPosition.X + 1),
-                y: (int)(mPosition.Y + 2),
+                x: (int)(Position.X + 1),
+                y: (int)(Position.Y + 2),
                 width: (int)(mSize.X - 2),
                 height: (int)(mSize.Y - 2)
                 );
             mBorderRectangle = new Rectangle(
-                x: (int)mPosition.X,
-                y: (int)mPosition.Y,
+                x: (int)Position.X,
+                y: (int)Position.Y,
                 width: (int)mSize.X,
                 height: (int)mSize.Y
                 );
 
             // ScissorRectangle will cut everything drawn outside of this rectangle when set
             mScissorRectangle = new Rectangle(
-                x: (int)(mPosition.X + 10),
-                y: (int)(mPosition.Y + titleSizeY + 30),
+                x: (int)(Position.X + 10),
+                y: (int)(Position.Y + titleSizeY + 30),
                 width: mWindowRectangle.Width - 20,
                 height: (int)(mSize.Y - titleSizeY - 3 * 10 - buttonSize.Y)
                 );
 
             // set the rectangle of the title bar
             mTitleBarRectangle = new Rectangle(
-                x: (int)mPosition.X + 10,
-                y: (int)mPosition.Y + titleSizeY + 20,
+                x: (int)Position.X + 10,
+                y: (int)Position.Y + titleSizeY + 20,
                 width: (int)mSize.X - 40,
                 height: 1
                 );
 
             // set the rectangle of the button
             mButtonBorderRectangle = new Rectangle(
-                x: (int)(mPosition.X + mSize.X / 2 - buttonSize.X / 2),
-                y: (int)(mPosition.Y + mSize.Y - buttonSize.Y + 1),
+                x: (int)(Position.X + mSize.X / 2 - buttonSize.X / 2),
+                y: (int)(Position.Y + mSize.Y - buttonSize.Y + 1),
                 width: (int)buttonSize.X,
                 height: (int)buttonSize.Y - 2);
 
             // set the rectangle for scrolling
             mScrollBarBorderRectangle = new Rectangle(
-                x: (int)(mPosition.X + mSize.X - 20),
+                x: (int)(Position.X + mSize.X - 20),
                 y: mScissorRectangle.Y,
                 width: 20,
                 height: mScissorRectangle.Height
@@ -181,7 +180,7 @@ namespace Singularity.Screen.ScreenClasses
             spriteBatch.StrokedRectangle(new Vector2(mWindowRectangle.X, mWindowRectangle.Y), new Vector2(mWindowRectangle.Width, mWindowRectangle.Height), mColorBorder, mColorFill, 1f, 0.8f );
 
             // draw window title + bar
-            spriteBatch.DrawString(mSpriteFontTitle, mWindowName, new Vector2(mPosition.X + 10, mPosition.Y + 10), new Color(255, 255, 255));
+            spriteBatch.DrawString(mSpriteFontTitle, mWindowName, new Vector2(Position.X + 10, Position.Y + 10), new Color(255, 255, 255));
             //spriteBatch.DrawRectangle(mTitleBarRectangle, mColorBorder, 1);
             spriteBatch.StrokedRectangle(new Vector2(mTitleBarRectangle.X, mTitleBarRectangle.Y), new Vector2(mTitleBarRectangle.Width, mTitleBarRectangle.Height), mColorBorder, mColorFill, 1f, 0.8f );
 
@@ -258,8 +257,8 @@ namespace Singularity.Screen.ScreenClasses
             // enabled only if
             //  - the mouse is above the scrollable part of the window
             //  - the window is scrollable (the number of items is too big for one window)
-            if (!(mMouseX > mPosition.X) || !(mMouseX < mPosition.X + mSize.X) || !(mMouseY > mPosition.Y) ||
-                !(mMouseY < mPosition.Y + mSize.Y) || !mScrollable)
+            if (!(mMouseX > Position.X) || !(mMouseX < Position.X + mSize.X) || !(mMouseY > Position.Y) ||
+                !(mMouseY < Position.Y + mSize.Y) || !mScrollable)
             {
                 return true;
             }
@@ -313,7 +312,10 @@ namespace Singularity.Screen.ScreenClasses
             // calculate new position
             var positionY = mScrollBarBorderRectangle.Y + numberOfStepsTaken * stepSize + 3;
 
-            return new Rectangle((int)(mPosition.X + mSize.X - 20 + 2), (int)positionY, 20 - 4, (int)sizeY);
+            return new Rectangle((int)(Position.X + mSize.X - 20 + 2), (int)positionY, 20 - 4, (int)sizeY);
         }
+
+        // position of the window
+        public Vector2 Position { get; set; }
     }
 }

--- a/Singularity/Singularity/Screen/ScreenClasses/UserInterfaceScreen.cs
+++ b/Singularity/Singularity/Screen/ScreenClasses/UserInterfaceScreen.cs
@@ -198,10 +198,6 @@ namespace Singularity.Screen.ScreenClasses
             }
 
             #endregion
-
-            // update screen size TODO : UPDATE POSITIONS OF THE WINDOWS WHEN RES-CHANGE IN PAUSE MENU
-            mCurrentScreenWidth = mGraphics.PreferredBackBufferWidth;
-            mCurrentScreenHeight = mGraphics.PreferredBackBufferHeight;
         }
 
         public void Draw(SpriteBatch spriteBatch)
@@ -246,32 +242,38 @@ namespace Singularity.Screen.ScreenClasses
             mCurrentScreenWidth = mGraphics.PreferredBackBufferWidth;
             mCurrentScreenHeight = mGraphics.PreferredBackBufferHeight;
 
+            System.Diagnostics.Debug.WriteLine(mGraphics.PreferredBackBufferWidth);
+            System.Diagnostics.Debug.WriteLine(mGraphics.PreferredBackBufferHeight);
+
             #region windows pos+size calculation
             // TODO : CHANGE TO FIX VALUES
             // change color for the border or the filling of all userinterface windows here
             var windowColor = new Color(0.27f, 0.5f, 0.7f, 0.8f);
             var borderColor = new Color(0.68f, 0.933f, 0.933f, .8f);
 
+/*
             // position + size of topBar
-            var topBarHeight = mCurrentScreenHeight / 30;
+            var topBarHeight = 720 / 30;
             var topBarWidth = mCurrentScreenWidth;
+*/
+
 
             // position + size of civilUnits window
-            var civilUnitsX = topBarHeight / 2;
-            var civilUnitsY = topBarHeight / 2 + topBarHeight;
-            var civilUnitsWidth = (int)(mCurrentScreenWidth / 4.5);
-            var civilUnitsHeight = (int)(mCurrentScreenHeight / 1.8);
+            var civilUnitsWidth = (int)(1080 / 4.5);
+            var civilUnitsHeight = (int)(720 / 1.8);
+            var civilUnitsX = 0;
+            var civilUnitsY = 720 / 30 + 24;
 
             // position + size of resource window
-            var resourceX = topBarHeight / 2;
-            var resourceY = 2 * (topBarHeight / 2) + topBarHeight + civilUnitsHeight;
+            var resourceX = 0; //12
+            var resourceY = 2 * (24 / 2) + 48 + civilUnitsHeight;
             var resourceWidth = civilUnitsWidth;
-            var resourceHeight = (int)(mCurrentScreenHeight / 2.75);
+            var resourceHeight = (int)(720 / 2.75);
 
             // position + size of eventLog window
             var eventLogWidth = civilUnitsWidth;
-            var eventLogHeight = (int)(mCurrentScreenHeight / 2.5);
-            var eventLogX = mCurrentScreenWidth - eventLogWidth - topBarHeight / 2;
+            var eventLogHeight = (int)(720 / 2.5);
+            var eventLogX = mCurrentScreenWidth - eventLogWidth;
             var eventLogY = civilUnitsY;
 
             // position + size of buildMenu window

--- a/Singularity/Singularity/Screen/ScreenClasses/UserInterfaceScreen.cs
+++ b/Singularity/Singularity/Screen/ScreenClasses/UserInterfaceScreen.cs
@@ -321,7 +321,7 @@ namespace Singularity.Screen.ScreenClasses
             // TODO : ADD INFO BAR
             /*
                         // position + size of topBar
-                        var topBarHeight = 720 / 30;
+                        var topBarHeight = 25;
                         var topBarWidth = mCurrentScreenWidth;
             */
 
@@ -982,23 +982,15 @@ namespace Singularity.Screen.ScreenClasses
         {
             // resource window position
             mResourceWindow.Position = new Vector2(12, mCurrentScreenHeight - 12 - mResourceWindow.Size.Y);
-/*            var resourceX = 12;
-            var resourceY = mCurrentScreenHeight - 12 - mResourceWindow.Size.Y;*/
 
             // civil units position
-            mCivilUnitsWindow.Position = new Vector2(12, mCurrentScreenHeight - 12 - 12 - mResourceWindow.Size.Y - mCivilUnitsWindow.Size.Y);
-/*            var civilUnitsX = 12;
-            var civilUnitsY = mCurrentScreenHeight - 12 - 12 - mResourceWindow.Size.Y - mCivilUnitsWindow.Size.Y;*/
+            mCivilUnitsWindow.Position = new Vector2(12, 12 + 25);
 
             // build menu position
             mBuildMenuWindow.Position = new Vector2(mCurrentScreenWidth - 12 - mBuildMenuWindow.Size.X, mCurrentScreenHeight - 12 - mBuildMenuWindow.Size.Y);
-/*            float buildMenuX = mCurrentScreenWidth - 12 - mBuildMenuWindow.Size.X;
-            float buildMenuY = mCurrentScreenHeight - 12 - mBuildMenuWindow.Size.Y;*/
 
             // event log position
-            mEventLogWindow.Position = new Vector2(mCurrentScreenWidth - 12 - mEventLogWindow.Size.X, mCurrentScreenHeight - 12 - 12 - mBuildMenuWindow.Size.Y - mEventLogWindow.Size.Y);
-/*            var eventLogX = mCurrentScreenWidth -  12 - mEventLogWindow.Size.X;
-            var eventLogY = mCurrentScreenHeight - 12 - 12 - mBuildMenuWindow.Size.Y - mEventLogWindow.Size.Y;*/
+            mEventLogWindow.Position = new Vector2(mCurrentScreenWidth - 12 - mEventLogWindow.Size.X, 12 + 25);
         }
 
         // TODO : ADD ALL BUILD PLATFORM ACTIONS

--- a/Singularity/Singularity/Screen/ScreenClasses/UserInterfaceScreen.cs
+++ b/Singularity/Singularity/Screen/ScreenClasses/UserInterfaceScreen.cs
@@ -40,6 +40,13 @@ namespace Singularity.Screen.ScreenClasses
         private int mCurrentScreenWidth;
         private int mCurrentScreenHeight;
 
+        // save the last resolution -> needed to update the window position when changes in res ingame
+        private int mPrevScreenWidth;
+        private int mPrevScreenHeight;
+
+        // director
+        private Director mDirector;
+
         // needed to calculate screen-sizes
         private readonly GraphicsDeviceManager mGraphics;
 
@@ -58,13 +65,19 @@ namespace Singularity.Screen.ScreenClasses
 
         #region civilUnitsWindow members
 
+        // civil units window
+        private WindowObject mCivilUnitsWindow;
+
+        // standard position
+        private Vector2 mCivilUnitsWindowStandardPos;
+
+        // sliders for distribution
         private Slider mDefSlider;
         private Slider mBuildSlider;
         private Slider mLogisticsSlider;
         private Slider mProductionSlider;
 
-        private Director mDirector;
-
+        // text for sliders
         private TextField mDefTextField;
         private TextField mBuildTextField;
         private TextField mLogisticsTextField;
@@ -74,11 +87,29 @@ namespace Singularity.Screen.ScreenClasses
 
         #region resourceWindow members
         // TODO : ALL WITH RESOURCE-IWindowItems
+
+        // resource window
+        private WindowObject mResourceWindow;
+
+        // standard position
+        private Vector2 mResourceWindowStandardPos;
+
+        #endregion
+
+        #region eventLog members
+        // TODO : IMPLEMENT EVENT LOG
+
+        // event log window
+        private WindowObject mEventLogWindow;
+
+        // standard position
+        private Vector2 mEventLogWindowStandardPos;
+
         #endregion
 
         #region buildMenuWindow members
-        
-        // build window
+
+        // build menu window
         private WindowObject mBuildMenuWindow;
 
         // vertical lists
@@ -111,7 +142,7 @@ namespace Singularity.Screen.ScreenClasses
         private Button mLaserTowerPlatformButton;
         private Button mBarracksPlatformButton;
 
-        // infoBox of buttons TODO
+        // infoBox of buttons TODO : ADD COSTS
         private InfoBoxWindow mInfoBuildBlank;
         private InfoBoxWindow mInfoBasicList;
         private InfoBoxWindow mInfoSpecialList;
@@ -183,6 +214,20 @@ namespace Singularity.Screen.ScreenClasses
 
         public void Update(GameTime gametime)
         {
+            // update screen size
+            mCurrentScreenWidth = mGraphics.PreferredBackBufferWidth;
+            mCurrentScreenHeight = mGraphics.PreferredBackBufferHeight;
+
+            // if the resolution has changed -> reset windows to standard positions
+            if (mCurrentScreenWidth != mPrevScreenWidth || mCurrentScreenHeight != mPrevScreenHeight)
+            {
+                mPrevScreenWidth = mCurrentScreenWidth;
+                mPrevScreenHeight = mCurrentScreenHeight;
+
+                // reset position to standard position
+                ResetWindowsToStandardPositon();
+            }
+
             // update all windows
             foreach (var window in mWindowList)
             {
@@ -221,10 +266,6 @@ namespace Singularity.Screen.ScreenClasses
             {
                 mCanBuildPlatform = true;
             }
-
-            // update screen size TODO : UPDATE POSITIONS OF THE WINDOWS WHEN RES-CHANGE IN PAUSE MENU
-            mCurrentScreenWidth = mGraphics.PreferredBackBufferWidth;
-            mCurrentScreenHeight = mGraphics.PreferredBackBufferHeight;
         }
 
         public void Draw(SpriteBatch spriteBatch)
@@ -268,46 +309,38 @@ namespace Singularity.Screen.ScreenClasses
             // resolution
             mCurrentScreenWidth = mGraphics.PreferredBackBufferWidth;
             mCurrentScreenHeight = mGraphics.PreferredBackBufferHeight;
+            mPrevScreenWidth = mCurrentScreenWidth;
+            mPrevScreenHeight = mCurrentScreenHeight;
 
-            System.Diagnostics.Debug.WriteLine(mGraphics.PreferredBackBufferWidth);
-            System.Diagnostics.Debug.WriteLine(mGraphics.PreferredBackBufferHeight);
-
-            #region windows pos+size calculation
-            // TODO : CHANGE TO FIX VALUES
             // change color for the border or the filling of all userinterface windows here
             var windowColor = new Color(0.27f, 0.5f, 0.7f, 0.8f);
             var borderColor = new Color(0.68f, 0.933f, 0.933f, .8f);
 
-/*
-            // position + size of topBar
-            var topBarHeight = 720 / 30;
-            var topBarWidth = mCurrentScreenWidth;
-*/
+            #region windows size calculation
+
+            // TODO : ADD INFO BAR
+            /*
+                        // position + size of topBar
+                        var topBarHeight = 720 / 30;
+                        var topBarWidth = mCurrentScreenWidth;
+            */
 
 
-            // position + size of civilUnits window
-            var civilUnitsWidth = (int)(1080 / 4.5);
-            var civilUnitsHeight = (int)(720 / 1.8);
-            var civilUnitsX = 0;
-            var civilUnitsY = 720 / 30 + 24;
+            // size of resource window
+            const float resourceWidth = 240;
+            const float resourceHeight = 262;
 
-            // position + size of resource window
-            var resourceX = 0; //12
-            var resourceY = 2 * (24 / 2) + 48 + civilUnitsHeight;
-            var resourceWidth = civilUnitsWidth;
-            var resourceHeight = (int)(720 / 2.75);
+            // size of civilUnits window
+            const float civilUnitsWidth = 240;
+            const float civilUnitsHeight = 400;
 
-            // position + size of eventLog window
-            var eventLogWidth = civilUnitsWidth;
-            var eventLogHeight = (int)(720 / 2.5);
-            var eventLogX = mCurrentScreenWidth - eventLogWidth;
-            var eventLogY = civilUnitsY;
+            // size of buildMenu window
+            const float buildMenuWidth = 240;
+            const float buildMenuHeight = 170;
 
-            // position + size of buildMenu window
-            var buildMenuWidth = eventLogWidth + 10;
-            var buildMenuHeight = eventLogHeight / 1.7; // TODO 
-            float buildMenuX = mCurrentScreenWidth - buildMenuWidth;
-            float buildMenuY = mCurrentScreenHeight - (float)buildMenuHeight;
+            // size of eventLog window
+            const float eventLogWidth = 240;
+            const float eventLogHeight = 288;
 
             #endregion
 
@@ -325,19 +358,18 @@ namespace Singularity.Screen.ScreenClasses
             // TODO
             #region eventLogWindow
 
-            var eventLogWindow = new WindowObject("// EVENT LOG", new Vector2(eventLogX, eventLogY), new Vector2(eventLogWidth, eventLogHeight), true, mLibSans14, mInputManager, mGraphics);
-
+            mEventLogWindow = new WindowObject("// EVENT LOG", new Vector2(0, 0), new Vector2(eventLogWidth, eventLogHeight), true, mLibSans14, mInputManager, mGraphics);
             // create items
 
             // add all items
 
-            mWindowList.Add(eventLogWindow);
+            mWindowList.Add(mEventLogWindow);
 
             #endregion
 
             #region civilUnitsWindow
 
-            var civilUnitsWindow = new WindowObject("// CIVIL UNITS", new Vector2(civilUnitsX, civilUnitsY), new Vector2(civilUnitsWidth, civilUnitsHeight), borderColor, windowColor, 10, 20, true, mLibSans14, mInputManager, mGraphics);
+            mCivilUnitsWindow = new WindowObject("// CIVIL UNITS", new Vector2(0, 0), new Vector2(civilUnitsWidth, civilUnitsHeight), borderColor, windowColor, 10, 20, true, mLibSans14, mInputManager, mGraphics);
 
             // create items
             //TODO: Create an object representing the Idle units at the moment. Something like "Idle: 24" should be enough
@@ -359,23 +391,23 @@ namespace Singularity.Screen.ScreenClasses
             //mProductionSlider.SliderMoving += mDirector.GetDistributionManager.ProductionSlider();
 
             // adding all items
-            civilUnitsWindow.AddItem(mDefTextField);
-            civilUnitsWindow.AddItem(mDefSlider);
-            civilUnitsWindow.AddItem(mBuildTextField);
-            civilUnitsWindow.AddItem(mBuildSlider);
-            civilUnitsWindow.AddItem(mLogisticsTextField);
-            civilUnitsWindow.AddItem(mLogisticsSlider);
-            civilUnitsWindow.AddItem(mProductionTextField);
-            civilUnitsWindow.AddItem(mProductionSlider);
+            mCivilUnitsWindow.AddItem(mDefTextField);
+            mCivilUnitsWindow.AddItem(mDefSlider);
+            mCivilUnitsWindow.AddItem(mBuildTextField);
+            mCivilUnitsWindow.AddItem(mBuildSlider);
+            mCivilUnitsWindow.AddItem(mLogisticsTextField);
+            mCivilUnitsWindow.AddItem(mLogisticsSlider);
+            mCivilUnitsWindow.AddItem(mProductionTextField);
+            mCivilUnitsWindow.AddItem(mProductionSlider);
 
-            mWindowList.Add(civilUnitsWindow);
+            mWindowList.Add(mCivilUnitsWindow);
 
             #endregion
 
             // TODO
             #region resourceWindow
 
-            var resourceWindow = new WindowObject("// RESOURCES", new Vector2(resourceX, resourceY), new Vector2(resourceWidth, resourceHeight), true, mLibSans14, mInputManager, mGraphics);
+            mResourceWindow = new WindowObject("// RESOURCES", new Vector2(0, 0), new Vector2(resourceWidth, resourceHeight), true, mLibSans14, mInputManager, mGraphics);
 
             // create items
 
@@ -395,19 +427,18 @@ namespace Singularity.Screen.ScreenClasses
 
             mTextFieldTest = new TextField(testText, Vector2.One, new Vector2(resourceWidth - 50, resourceHeight), mLibSans12);
 
-            resourceWindow.AddItem(mTextFieldTest);
+            mResourceWindow.AddItem(mTextFieldTest);
 
             #endregion
 
-            mWindowList.Add(resourceWindow);
+            mWindowList.Add(mResourceWindow);
 
             #endregion
 
             // TODO
-
             #region buildMenuWindow
 
-            mBuildMenuWindow = new WindowObject("// BUILDMENU", new Vector2(buildMenuX, buildMenuY), new Vector2(buildMenuWidth, (float)buildMenuHeight), true, mLibSans14, mInputManager, mGraphics);
+            mBuildMenuWindow = new WindowObject("// BUILDMENU", new Vector2(0, 0), new Vector2(buildMenuWidth, buildMenuHeight), true, mLibSans14, mInputManager, mGraphics);
 
             #region button definitions
 
@@ -876,26 +907,28 @@ namespace Singularity.Screen.ScreenClasses
             var specialList = new List<IWindowItem> { mJunkyardPlatformButton, mQuarryPlatformButton, mMinePlatformButton, mWellPlatformButton };
             var militaryList = new List<IWindowItem> { mArmoryPlatformButton, mKineticTowerPlatformButton, mLaserTowerPlatformButton, mBarracksPlatformButton };
             // create the horizontalCollection objects which process the button-row placement
-            mButtonTopList = new HorizontalCollection(topList, new Vector2(buildMenuWidth - 20, mBlankPlatformButton.Size.X), Vector2.Zero);
-            mButtonBasicList = new HorizontalCollection(basicList, new Vector2(buildMenuWidth - 20, mBlankPlatformButton.Size.X), Vector2.Zero);
-            mButtonSpecialList = new HorizontalCollection(specialList, new Vector2(buildMenuWidth - 20, mBlankPlatformButton.Size.X), Vector2.Zero);
-            mButtonMilitaryList = new HorizontalCollection(militaryList, new Vector2(buildMenuWidth - 20, mBlankPlatformButton.Size.X), Vector2.Zero);
+            mButtonTopList = new HorizontalCollection(topList, new Vector2(buildMenuWidth - 30, mBlankPlatformButton.Size.X), Vector2.Zero);
+            mButtonBasicList = new HorizontalCollection(basicList, new Vector2(buildMenuWidth - 30, mBlankPlatformButton.Size.X), Vector2.Zero);
+            mButtonSpecialList = new HorizontalCollection(specialList, new Vector2(buildMenuWidth - 30, mBlankPlatformButton.Size.X), Vector2.Zero);
+            mButtonMilitaryList = new HorizontalCollection(militaryList, new Vector2(buildMenuWidth - 30, mBlankPlatformButton.Size.X), Vector2.Zero);
             // add the all horizontalCollection to the build menu window, but deactivate all but topList
             // (they get activated if the corresponding button is pressed)
             mBuildMenuWindow.AddItem(mButtonTopList);
-            mBuildMenuWindow.AddItem(mButtonMilitaryList);
-            mButtonMilitaryList.ActiveHorizontalCollection = false;
             mBuildMenuWindow.AddItem(mButtonBasicList);
-            mButtonBasicList.ActiveHorizontalCollection = false;
+            mButtonBasicList.ActiveHorizontalCollection = true;
             mBuildMenuWindow.AddItem(mButtonSpecialList);
             mButtonSpecialList.ActiveHorizontalCollection = false;
-            
+            mBuildMenuWindow.AddItem(mButtonMilitaryList);
+            mButtonMilitaryList.ActiveHorizontalCollection = false;
+
             // add the build menu to the UI's windowList
             mWindowList.Add(mBuildMenuWindow);
 
             #endregion
 
             #endregion
+
+            ResetWindowsToStandardPositon();
 
             // TODO : DELETE AFTER SPRINT
             #region testing popup window
@@ -944,6 +977,29 @@ namespace Singularity.Screen.ScreenClasses
         }
 
         public bool Loaded { get; set; }
+
+        private void ResetWindowsToStandardPositon()
+        {
+            // resource window position
+            mResourceWindow.Position = new Vector2(12, mCurrentScreenHeight - 12 - mResourceWindow.Size.Y);
+/*            var resourceX = 12;
+            var resourceY = mCurrentScreenHeight - 12 - mResourceWindow.Size.Y;*/
+
+            // civil units position
+            mCivilUnitsWindow.Position = new Vector2(12, mCurrentScreenHeight - 12 - 12 - mResourceWindow.Size.Y - mCivilUnitsWindow.Size.Y);
+/*            var civilUnitsX = 12;
+            var civilUnitsY = mCurrentScreenHeight - 12 - 12 - mResourceWindow.Size.Y - mCivilUnitsWindow.Size.Y;*/
+
+            // build menu position
+            mBuildMenuWindow.Position = new Vector2(mCurrentScreenWidth - 12 - mBuildMenuWindow.Size.X, mCurrentScreenHeight - 12 - mBuildMenuWindow.Size.Y);
+/*            float buildMenuX = mCurrentScreenWidth - 12 - mBuildMenuWindow.Size.X;
+            float buildMenuY = mCurrentScreenHeight - 12 - mBuildMenuWindow.Size.Y;*/
+
+            // event log position
+            mEventLogWindow.Position = new Vector2(mCurrentScreenWidth - 12 - mEventLogWindow.Size.X, mCurrentScreenHeight - 12 - 12 - mBuildMenuWindow.Size.Y - mEventLogWindow.Size.Y);
+/*            var eventLogX = mCurrentScreenWidth -  12 - mEventLogWindow.Size.X;
+            var eventLogY = mCurrentScreenHeight - 12 - 12 - mBuildMenuWindow.Size.Y - mEventLogWindow.Size.Y;*/
+        }
 
         // TODO : ADD ALL BUILD PLATFORM ACTIONS
         #region button management

--- a/Singularity/Singularity/Screen/ScreenClasses/UserInterfaceScreen.cs
+++ b/Singularity/Singularity/Screen/ScreenClasses/UserInterfaceScreen.cs
@@ -1313,8 +1313,7 @@ namespace Singularity.Screen.ScreenClasses
 
         #endregion
 
-        // All build buttons show a little info window at the mouse pointer showing costs + name what gets build
-        // while the mouse is hovering above the button
+        // All build buttons show a little info window mouse is hovering of costs + name of what gets build
         #region buttonHovering Info
 
         // NOTICE : all following hovering- or hoveringEnd- methods do basically the same:

--- a/Singularity/Singularity/Screen/WindowObject.cs
+++ b/Singularity/Singularity/Screen/WindowObject.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Singularity.Input;
@@ -19,8 +18,6 @@ namespace Singularity.Screen
 
         // parameters
         private readonly string mWindowName; // the window name is the windows title
-        private Vector2 mPosition; // position of the window
-        private readonly Vector2 mSize; // size of the window
         private readonly Color mColorBorder; // color of the windowborder
         private readonly Color mColorFill; // color of the window background
         private readonly float mBorderPadding; // gap between items and the left window border
@@ -66,6 +63,7 @@ namespace Singularity.Screen
         // top and bottom positin of the window's combined items - used by scrolling
         private Vector2 mItemPosTop;
         private Vector2 mItemPosBottom;
+        private int mItemScrolledValue;
 
         // height of all windowItems with borderpaddings - used to implement scrollable windows if needed
         private float mCombinedItemsSize;
@@ -115,8 +113,8 @@ namespace Singularity.Screen
         {
             // use parameter-variables
             mWindowName = windowName;
-            mPosition = position;
-            mSize = size;
+            Position = position;
+            Size = size;
             mColorBorder = new Color(0.68f, 0.933f, 0.933f, .8f);
             mColorFill = new Color(0.27f, 0.5f, 0.7f, 0.8f);
             mBorderPadding = 10f;
@@ -170,8 +168,8 @@ namespace Singularity.Screen
         {
             // set parameter-variables
             mWindowName = windowName;
-            mPosition = position;
-            mSize = size;
+            Position = position;
+            Size = size;
             mColorBorder = colorBorder;
             mColorFill = colorFill;
             mBorderPadding = borderPadding;
@@ -224,8 +222,8 @@ namespace Singularity.Screen
         {
             // set parameter-variables
             mWindowName = windowName;
-            mPosition = position;
-            mSize = size;
+            Position = position;
+            Size = size;
             mColorBorder = colorBorder;
             mColorFill = colorBorder;
             mBorderPadding = borderPadding;
@@ -258,14 +256,11 @@ namespace Singularity.Screen
         private void Initialization()
         {
             // calculate resizing by screensize
-            mMinimizationSize = (int)mSize.X / 12;
+            mMinimizationSize = (int)Size.X / 12;
             mTitleSizeY = 720 / 26;
 
-            // position where the next item will be drawn
-            mItemPosTop = new Vector2(mPosition.X + mBorderPadding, mPosition.Y + mTitleSizeY + 2 * mMinimizationSize);
-
-            // Only input from inside the window is proccessed
-            Bounds = new Rectangle((int)mPosition.X, (int)mPosition.Y, (int)(mSize.X), ((int)mSize.Y));
+            // int to save scroll values
+            mItemScrolledValue = 0;
 
             // activate window
             Active = true;
@@ -365,7 +360,7 @@ namespace Singularity.Screen
             }
 
             // draw window title + bar
-            spriteBatch.DrawString(mSpriteFont, mWindowName, new Vector2(mPosition.X + mMinimizationSize / 2f, mPosition.Y + mMinimizationSize / 2f), new Color(255, 255, 255));
+            spriteBatch.DrawString(mSpriteFont, mWindowName, new Vector2(Position.X + mMinimizationSize / 2f, Position.Y + mMinimizationSize / 2f), new Color(255, 255, 255));
             spriteBatch.DrawRectangle(mTitleBarRectangle, mColorBorder, 1);
         }
 
@@ -375,6 +370,26 @@ namespace Singularity.Screen
                 // window is deactivated
             {
                 return;
+            }
+
+            // position where the next item will be drawn
+            mItemPosTop = new Vector2(Position.X + mBorderPadding, Position.Y + mTitleSizeY + 2 * mMinimizationSize + mItemScrolledValue);
+
+            // update Bounds
+            if (mClickOnTitleBar)
+            {
+                // Bounds include the entire screen, so that the window can be moved everywhere
+                Bounds = new Rectangle(0, 0, mCurrentScreenWidth, mCurrentScreenHeight);
+            }
+            else if (!mMinimized)
+            {
+                // input from inside the window is proccessed
+                Bounds = new Rectangle((int)Position.X, (int)Position.Y, (int)(Size.X), ((int)Size.Y));
+            }
+            else
+            {
+                // input from inside the minimized window is proccessed
+                Bounds = new Rectangle(mMinimizedBorderRectangle.X, mMinimizedBorderRectangle.Y, mMinimizedBorderRectangle.Width, mMinimizedBorderRectangle.Height);
             }
 
             // current position to place the next item
@@ -404,69 +419,69 @@ namespace Singularity.Screen
 
             // set the window rectangle
             mWindowRectangle = new Rectangle(
-                x: (int)(mPosition.X + 1),
-                y: (int)(mPosition.Y + 2),
-                width: (int)(mSize.X - 2),
-                height: (int)(mSize.Y - 2)
+                x: (int)(Position.X + 1),
+                y: (int)(Position.Y + 2),
+                width: (int)(Size.X - 2),
+                height: (int)(Size.Y - 2)
                 );
             mBorderRectangle = new Rectangle(
-                x: (int)mPosition.X,
-                y: (int)mPosition.Y,
-                width: (int)mSize.X,
-                height: (int)mSize.Y
+                x: (int)Position.X,
+                y: (int)Position.Y,
+                width: (int)Size.X,
+                height: (int)Size.Y
                 );
 
             // ScissorRectangle will cut everything drawn outside of this rectangle when set
             mScissorRectangle = new Rectangle(
-                x: (int)(mPosition.X - 1),
-                y: (int)(mPosition.Y + mTitleSizeY + 2 * mMinimizationSize),
-                width: (int)(mSize.X + 2),
-                height: (int)(mSize.Y + 2 - mTitleSizeY - 2 * mMinimizationSize - 2)
+                x: (int)(Position.X - 1),
+                y: (int)(Position.Y + mTitleSizeY + 2 * mMinimizationSize),
+                width: (int)(Size.X + 2),
+                height: (int)(Size.Y + 2 - mTitleSizeY - 2 * mMinimizationSize - 2)
                 );
 
             // set the rectangle for minimization in the top right corner of the window
             mMinimizationRectangle = new Rectangle(
-                x: (int)(mPosition.X + mSize.X - mMinimizationSize),
-                y: (int)mPosition.Y,
+                x: (int)(Position.X + Size.X - mMinimizationSize),
+                y: (int)Position.Y,
                 width: mMinimizationSize,
                 height: mMinimizationSize
                 );
             mMinimizationLine = new Rectangle(
-                x: (int)(mPosition.X + mSize.X - 3 * mMinimizationSize / 4f),
-                y: (int)(mPosition.Y + mMinimizationSize / 2f),
+                x: (int)(Position.X + Size.X - 3 * mMinimizationSize / 4f),
+                y: (int)(Position.Y + mMinimizationSize / 2f),
                 width: mMinimizationSize / 2,
                 height: 1
                 );
 
             // set the rectangle for the minimized window
             mMinimizedWindowRectangle = new Rectangle(
-                x: (int)(mPosition.X + 1),
-                y: (int)(mPosition.Y + 2),
-                width: (int)mSize.X - 2,
+                x: (int)(Position.X + 1),
+                y: (int)(Position.Y + 2),
+                width: (int)Size.X - 2,
                 height: mTitleSizeY + mMinimizationSize
                 );
             mMinimizedBorderRectangle = new Rectangle(
-                x: (int)mPosition.X,
-                y: (int)mPosition.Y,
-                width: (int)mSize.X,
+                x: (int)Position.X,
+                y: (int)Position.Y,
+                width: (int)Size.X,
                 height: mTitleSizeY + mMinimizationSize
                 );
 
             // set the rectangle for scrolling
             mScrollBarBorderRectangle = new Rectangle(
-                x: (int)(mPosition.X + mSize.X - mMinimizationSize),
-                y: (int)(mPosition.Y + mTitleSizeY + 2 * mMinimizationSize),
+                x: (int)(Position.X + Size.X - mMinimizationSize),
+                y: (int)(Position.Y + mTitleSizeY + 2 * mMinimizationSize),
                 width: mMinimizationSize,
-                height: (int)(mSize.Y - mTitleSizeY - 3 * mMinimizationSize)
+                height: (int)(Size.Y - mTitleSizeY - 3 * mMinimizationSize)
                 );
             mScrollBarRectangle = CalcScrollbarRectangle(mScissorRectangle, mCombinedItemsSize
             );
 
             // set the rectangle of the title bar
             mTitleBarRectangle = new Rectangle(
-                x: (int)mPosition.X + mMinimizationSize / 2,
-                y: (int)mPosition.Y + mTitleSizeY + mMinimizationSize,
-                width: (int)mSize.X - 2 * mMinimizationSize,
+                x: (int)Position.X + mMinimizationSize / 2,
+                y: (int)Position.Y + mTitleSizeY + mMinimizationSize,
+                width: (int)Size.X - 2 * mMinimizationSize,
                 height: 1
                 );
         }
@@ -484,24 +499,24 @@ namespace Singularity.Screen
             //  - the window is not minimized
             //  - the window is scrollable (the number of items is too big for one window)
             //  - the window is active
-            if (mMouseX > mPosition.X && mMouseX < mPosition.X + mSize.X && mMouseY > mPosition.Y &&
-                mMouseY < mPosition.Y + mSize.Y && !mMinimized && mScrollable && Active)
+            if (mMouseX > Position.X && mMouseX < Position.X + Size.X && mMouseY > Position.Y &&
+                mMouseY < Position.Y + Size.Y && !mMinimized && mScrollable && Active)
             {
                 // scroll up or down
                 switch (mouseAction)
                 {
                     case EMouseAction.ScrollUp:
-                        if (!(mItemPosTop.Y > mPosition.Y + mTitleSizeY + 1.5 * mMinimizationSize))
+                        if (!(mItemPosTop.Y > Position.Y + mTitleSizeY + 1.5 * mMinimizationSize))
                             // stop from overflowing
                         {
-                            mItemPosTop.Y += +10;
+                            mItemScrolledValue += +10;
                         }
                         break;
                     case EMouseAction.ScrollDown:
-                        if (!(mItemPosBottom.Y < mPosition.Y + mSize.Y))
+                        if (!(mItemPosBottom.Y < Position.Y + Size.Y))
                             // stop from overflowing
                         {
-                            mItemPosTop.Y += -10;
+                            mItemScrolledValue += -10;
                         }
                         break;
                 }
@@ -509,8 +524,8 @@ namespace Singularity.Screen
 
             // everything following handles if the input is given through or not
             if (!mMinimized &&
-                (mMouseX > mPosition.X && mMouseX < mPosition.X + mSize.X &&
-                 mMouseY > mPosition.Y && mMouseY < mPosition.Y + mSize.Y))
+                (mMouseX > Position.X && mMouseX < Position.X + Size.X &&
+                 mMouseY > Position.Y && mMouseY < Position.Y + Size.Y))
                 // not minimized + mouse on window
             {
                 return false;
@@ -518,8 +533,8 @@ namespace Singularity.Screen
 
             // resharper wanted it this 'overseeable' way o.O
             // minimized + mouse on minimized window -> return false ... else true
-            return !mMinimized || (!(mMouseX > mPosition.X) || !(mMouseX < mMinimizedBorderRectangle.X + mMinimizedBorderRectangle.Width) || 
-                                   !(mMouseY > mPosition.Y) || !(mMouseY < mMinimizedBorderRectangle.Y + mMinimizedBorderRectangle.Height));
+            return !mMinimized || (!(mMouseX > Position.X) || !(mMouseX < mMinimizedBorderRectangle.X + mMinimizedBorderRectangle.Width) || 
+                                   !(mMouseY > Position.Y) || !(mMouseY < mMinimizedBorderRectangle.Y + mMinimizedBorderRectangle.Height));
         }
 
         public bool MouseButtonClicked(EMouseAction mouseAction, bool withinBounds)
@@ -539,8 +554,6 @@ namespace Singularity.Screen
                     // -> use minimized rectangles
                     {
                         mMinimized = true;
-                        // Only input from inside the minimized rectangle is proccessed
-                        Bounds = new Rectangle(mMinimizedBorderRectangle.X, mMinimizedBorderRectangle.Y, mMinimizedBorderRectangle.Width, mMinimizedBorderRectangle.Height);
 
                         // disable all items due to minimization
                         foreach (var item in mItemList)
@@ -553,8 +566,6 @@ namespace Singularity.Screen
                     // -> use regular rectangles + move window back in screen if outside
                     {
                         mMinimized = false;
-                        // Only input from inside the window is proccessed
-                        Bounds = new Rectangle((int)mPosition.X, (int)mPosition.Y, (int)(mSize.X), ((int)mSize.Y));
 
                         // enable all items due to maximization
                         foreach (var item in mItemList)
@@ -563,12 +574,10 @@ namespace Singularity.Screen
                         }
 
                         // catch window being out of screen at the bottom after maximization
-                        if (mPosition.Y + mSize.Y > mCurrentScreenHeight)
+                        if (Position.Y + Size.Y > mCurrentScreenHeight)
                         {
                             // reset window position
-                            mPosition.Y = mCurrentScreenHeight - mSize.Y;
-                            // reset item position
-                            mItemPosTop = new Vector2(mPosition.X + mBorderPadding, mPosition.Y + mTitleSizeY + 2 * mMinimizationSize);
+                            Position = new Vector2(Position.X, mCurrentScreenHeight - Size.Y);
                         }
                     }
                 }
@@ -577,10 +586,10 @@ namespace Singularity.Screen
 
                 #region window movement initiation
 
-            if (mMouseX > mPosition.X &&
-                mMouseX < mPosition.X + mPosition.X + mSize.X &&
-                mMouseY > mPosition.Y &&
-                mMouseY < mPosition.Y + mTitleSizeY + mMinimizationSize &&
+            if (mMouseX > Position.X &&
+                mMouseX < Position.X + Position.X + Size.X &&
+                mMouseY > Position.Y &&
+                mMouseY < Position.Y + mTitleSizeY + mMinimizationSize &&
                 !mClickOnTitleBar)
                 // mouse above the title rectangle
                 {
@@ -593,10 +602,7 @@ namespace Singularity.Screen
                         mClickOnTitleBar = true;
 
                         // set 'previous mouse position'
-                        mWindowDragPos = new Vector2(mMouseX - mPosition.X, mMouseY - mPosition.Y);
-
-                        // new Bounds so that the window can be moved everywhere
-                        Bounds = new Rectangle(0, 0, mCurrentScreenWidth, mCurrentScreenHeight);
+                        mWindowDragPos = new Vector2(mMouseX - Position.X, mMouseY - Position.Y);
                     }
                 }
 
@@ -607,8 +613,8 @@ namespace Singularity.Screen
             // everything following handles if the input is given through or not
 
             if (!mMinimized &&
-                (mMouseX > mPosition.X && mMouseX < mPosition.X + mSize.X &&
-                 mMouseY > mPosition.Y && mMouseY < mPosition.Y + mSize.Y))
+                (mMouseX > Position.X && mMouseX < Position.X + Size.X &&
+                 mMouseY > Position.Y && mMouseY < Position.Y + Size.Y))
                 // not minimized + mouse on window
             {
                 return false;
@@ -616,8 +622,8 @@ namespace Singularity.Screen
 
             // resharper wanted it this 'overseeable' way o.O
             // minimized + mouse on minimized window -> return false ... else true
-            return !(mMinimized && mMouseX > mPosition.X && mMouseX < mMinimizedBorderRectangle.X + mMinimizedBorderRectangle.Width &&
-                                   mMouseY > mPosition.Y && mMouseY < mMinimizedBorderRectangle.Y + mMinimizedBorderRectangle.Height);
+            return !(mMinimized && mMouseX > Position.X && mMouseX < mMinimizedBorderRectangle.X + mMinimizedBorderRectangle.Width &&
+                                   mMouseY > Position.Y && mMouseY < mMinimizedBorderRectangle.Y + mMinimizedBorderRectangle.Height);
         }
 
         public bool MouseButtonPressed(EMouseAction mouseAction, bool withinBounds)
@@ -628,55 +634,51 @@ namespace Singularity.Screen
                 // enable single window movement + no reaction when deactivated
             {
                 // backup old window position to calculate the movement
-                var positionOld = mPosition;
+                var positionOld = Position;
 
                 // update window position
-                mPosition.X = mMouseX - mWindowDragPos.X;
-                mPosition.Y = mMouseY - mWindowDragPos.Y;
+                Position = new Vector2(mMouseX - mWindowDragPos.X, mMouseY - mWindowDragPos.Y);
 
                 #region catch window moving out of screen
                 // catch left / right
-                if (mPosition.X < 0)
+                if (Position.X < 0)
                 {
-                    mPosition.X = 0;
+                    Position = new Vector2(0, Position.Y);
                 }
-                else if (mPosition.X + mSize.X > mCurrentScreenWidth)
+                else if (Position.X + Size.X > mCurrentScreenWidth)
                 {
-                    mPosition.X = mCurrentScreenWidth - mSize.X;
+                    Position = new Vector2(mCurrentScreenWidth - Size.X, Position.Y);
                 }
 
                 // catch top / bottom
                 if (!mMinimized)
                     // full window
                 {
-                    if (mPosition.Y < 0)
+                    if (Position.Y < 0)
                     {
-                        mPosition.Y = 0;
+                        Position = new Vector2(Position.X, 0);
                     }
-                    else if (mPosition.Y + mSize.Y > mCurrentScreenHeight)
+                    else if (Position.Y + Size.Y > mCurrentScreenHeight)
                     {
-                        mPosition.Y = mCurrentScreenHeight - mSize.Y;
+                        Position = new Vector2(Position.X, mCurrentScreenHeight - Size.Y);
                     }
                 }
                 else
                     // minimized window
                 {
-                    if (mPosition.Y < 0)
+                    if (Position.Y < 0)
                     {
-                        mPosition.Y = 0;
+                        Position = new Vector2(Position.X, 0);
                     }
-                    else if (mPosition.Y + mMinimizedBorderRectangle.Height > mCurrentScreenHeight)
+                    else if (Position.Y + mMinimizedBorderRectangle.Height > mCurrentScreenHeight)
                     {
-                        mPosition.Y = mCurrentScreenHeight - mSize.Y;
+                        Position = new Vector2(Position.X, mCurrentScreenHeight - Size.Y);
                     }
                 }
                 #endregion
 
                 // calculate the movement
-                var movementVector = new Vector2(mPosition.X - positionOld.X, mPosition.Y - positionOld.Y);
-
-                // item movement
-                mItemPosTop = new Vector2(mItemPosTop.X + movementVector.X, mItemPosTop.Y + movementVector.Y);
+                var movementVector = new Vector2(Position.X - positionOld.X, Position.Y - positionOld.Y);
             }
 
             #endregion
@@ -693,17 +695,6 @@ namespace Singularity.Screen
             }
 
             mClickOnTitleBar = false;
-
-            if (mMinimized)
-            {
-                // window minimized -> only input from inside the minimized window is proccessed
-                Bounds = new Rectangle(mMinimizedBorderRectangle.X, mMinimizedBorderRectangle.Y, mMinimizedBorderRectangle.Width, mMinimizedBorderRectangle.Height);
-            }
-            else
-            {
-                // window maximized -> input the maximized window is proccessed
-                Bounds = new Rectangle((int)mPosition.X, (int)mPosition.Y, (int)mSize.X, (int)mSize.Y);
-            }
 
             return false;
         }
@@ -742,9 +733,16 @@ namespace Singularity.Screen
             // calculate new position
             var positionY = mScrollBarBorderRectangle.Y + numberOfStepsTaken * stepSize + 3;
 
-            return new Rectangle((int)(mPosition.X + mSize.X - mMinimizationSize + 2), (int)positionY, mMinimizationSize - 4, (int)sizeY);
+            return new Rectangle((int)(Position.X + Size.X - mMinimizationSize + 2), (int)positionY, mMinimizationSize - 4, (int)sizeY);
         }
 
+        // true if window is active (window + items in window will be drawn/updated) or inactive (not drawn/updated)
         private bool Active { get; set; }
+
+        // position of the window
+        public Vector2 Position { private get; set; }
+
+        // size of the window
+        public Vector2 Size { get; }
     }
 }

--- a/Singularity/Singularity/Screen/WindowObject.cs
+++ b/Singularity/Singularity/Screen/WindowObject.cs
@@ -256,7 +256,7 @@ namespace Singularity.Screen
         private void Initialization()
         {
             // calculate resizing by screensize
-            mMinimizationSize = (int)Size.X / 12;
+            mMinimizationSize = 20;
             mTitleSizeY = 720 / 26;
 
             // int to save scroll values

--- a/Singularity/Singularity/Singularity.csproj
+++ b/Singularity/Singularity/Singularity.csproj
@@ -129,7 +129,7 @@
     <Compile Include="Screen\ITransitionableMenu.cs" />
     <Compile Include="Screen\IWindowItem.cs" />
     <Compile Include="Screen\ScreenClasses\GameScreen.cs" />
-    <Compile Include="Screen\ScreenClasses\PopupWindow.cs" />
+    <Compile Include="Screen\PopupWindow.cs" />
     <Compile Include="Screen\Slider.cs" />
     <Compile Include="Screen\ScreenClasses\UserInterfaceScreen.cs" />
     <Compile Include="Screen\Button.cs" />


### PR DESCRIPTION
The UI no longer changes the size of the windows using the resolution when the game is started with different resolutions. It does however change their position to place them at the border.
Updated bounds in window object s.t. the window gives input correctly through if minimized.

Currently NOT implemented: if the resolution is changed in game (pause menu) the windows don't change position automatically