### PR TITLE
Added multiple graph support

### DIFF
--- a/Singularity/Singularity/Graph/Graph.cs
+++ b/Singularity/Singularity/Graph/Graph.cs
@@ -90,5 +90,31 @@ namespace Singularity.Graph
             return mEdges;
         }
 
+        public override bool Equals(object obj)
+        {
+            var graph = obj as Graph;
+
+            if (graph == null)
+            {
+                return false;
+            }
+
+            if (!(graph.GetNodes().TrueForAll(GetNodes().Contains) && graph.GetNodes().Count == GetNodes().Count))
+            {
+                return false;
+            }
+
+            if (!(graph.GetEdges().TrueForAll(GetEdges().Contains) && graph.GetEdges().Count == GetEdges().Count))
+            {
+                return false;
+            }
+            return true;
+
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode() + mNodes.GetHashCode() * mEdges.GetHashCode();
+        }
     }
 }

--- a/Singularity/Singularity/Graph/INode.cs
+++ b/Singularity/Singularity/Graph/INode.cs
@@ -7,7 +7,9 @@ namespace Singularity.Graph
     /// </summary>
     public interface INode
     {
-        /// <summary>
+        IEnumerable<INode> GetChilds();
+
+            /// <summary>
         /// Gets all the edges facing outwards of this node.
         /// </summary>
         /// <returns>The edges mentioned</returns>

--- a/Singularity/Singularity/Graph/Paths/PathManager.cs
+++ b/Singularity/Singularity/Graph/Paths/PathManager.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
 using Singularity.Exceptions;
 using Singularity.Units;
 
@@ -14,21 +16,27 @@ namespace Singularity.Graph.Paths
         /// <summary>
         /// All the graphs currently in the game
         /// </summary>
-        private readonly List<Graph> mGraphs;
+        private readonly Dictionary<int, Graph> mGraphs;
 
         public PathManager()
         {
-            mGraphs = new List<Graph>();
+            mGraphs = new Dictionary<int, Graph>();
         }
 
-        public void AddGraph(Graph graph)
+        public void AddGraph(int id, Graph graph)
         {
-            mGraphs.Add(graph);
+
+            if (mGraphs.ContainsKey(id))
+            {
+                mGraphs[id] = graph;
+                return;
+            }
+            mGraphs.Add(id, graph);
         }
 
-        public void RemoveGraph(Graph graph)
+        public void RemoveGraph(int id)
         {
-            mGraphs.Remove(graph);
+            mGraphs.Remove(id);
         }
 
 
@@ -39,7 +47,7 @@ namespace Singularity.Graph.Paths
         /// <param name="unit">The unit which requests a path</param>
         /// <param name="destination">The destination to which the path should lead</param>
         /// <returns></returns>
-        public IPath GetPath<T>(T unit, INode destination)
+        public IPath GetPath<T>(T unit, INode destination, int GraphIndex)
         {
             // the basic idea for military and general units to use the same method and the distinuishing
             // between the two is handled here.
@@ -48,14 +56,14 @@ namespace Singularity.Graph.Paths
 
             if (asGeneralUnit != null)
             {
-                return GetPathForGeneralUnits(asGeneralUnit, destination);
+                return GetPathForGeneralUnits(asGeneralUnit, destination, GraphIndex);
             }
 
             var asMilitaryUnit = unit as MilitaryUnit;
 
             if (asMilitaryUnit != null)
             {
-                return GetPathForMilitaryUnits(asMilitaryUnit, destination);
+                return GetPathForMilitaryUnits(asMilitaryUnit, destination, GraphIndex);
             }
 
             throw new InvalidGenericArgumentException(
@@ -64,14 +72,14 @@ namespace Singularity.Graph.Paths
 
         }
 
-        private IPath GetPathForGeneralUnits(GeneralUnit unit, INode destination)
+        private IPath GetPathForGeneralUnits(GeneralUnit unit, INode destination, int GraphIndex)
         {
-            // todo: know which units are on which graph.
-            // todo: fix. @Ativolex @fkarg
-            return PathfindingFactory.GetPathfinding().AStar(mGraphs[0], unit.CurrentNode, destination);
+            //TODO: implement distribution on multiple graphs, then the following boolean expression can be removed
+
+            return PathfindingFactory.GetPathfinding().AStar(mGraphs[GraphIndex], unit.CurrentNode, destination);
         }
 
-        private IPath GetPathForMilitaryUnits(MilitaryUnit unit, INode destination)
+        private IPath GetPathForMilitaryUnits(MilitaryUnit unit, INode destination, int GraphIndex)
         {
             //todo: implement
             var pathfinding = PathfindingFactory.GetPathfinding();

--- a/Singularity/Singularity/Levels/Skirmish.cs
+++ b/Singularity/Singularity/Levels/Skirmish.cs
@@ -67,9 +67,14 @@ namespace Singularity.Levels
             //INGAME OBJECTS INITIALIZATION ===================================================
             //Platforms
             mPlatform = new PlatformBlank(new Vector2(1000, 1000), null, platformBlankTexture, ref mDirector);
+            mGameScreen.AddObject(mPlatform);
 
             // this is done via the factory to test, so I can instantly see if something is some time off.
             var platform2 = PlatformFactory.Get(EPlatformType.Well, ref mDirector, 800, 1000, mMap.GetResourceMap());
+            mGameScreen.AddObject(platform2);
+
+            var road1 = new Road(mPlatform, platform2, false);
+            mGameScreen.AddObject(road1);
 
             //var platform2 = new Well(new Vector2(800, 1000), platformDomeTexture, platformBlankTexture, mMap.GetResourceMap(), ref mDirector);
             var platform3 = new Quarry(new Vector2(1200, 1200),
@@ -77,9 +82,22 @@ namespace Singularity.Levels
                 platformBlankTexture,
                 mMap.GetResourceMap(),
                 ref mDirector);
+            mGameScreen.AddObject(platform3);
+            var road2 = new Road(platform2, platform3, false);
+            mGameScreen.AddObject(road2);
+            var road3 = new Road(platform3, mPlatform, false);
+            mGameScreen.AddObject(road3);
+
             var platform4 = new EnergyFacility(new Vector2(1000, 800),
                 platformDomeTexture,
                 platformBlankTexture, ref mDirector);
+            mGameScreen.AddObject(platform4);
+            var road4 = new Road(mPlatform, platform4, false);
+            mGameScreen.AddObject(road4);
+
+            var road5 = new Road(platform4, platform3, false);
+            mGameScreen.AddObject(road5);
+
 
             //GenUnits
             var genUnit = new GeneralUnit(mPlatform, ref mDirector);
@@ -93,13 +111,7 @@ namespace Singularity.Levels
 
             //SetUnit
             var setUnit = new Settler(new Vector2(1000, 1250), mCamera, ref mDirector, ref mMap, mGameScreen);
-
-            //Roads
-            var road1 = new Road(mPlatform, platform2, false);
-            var road2 = new Road(platform2, platform3, false);
-            var road3 = new Road(platform3, mPlatform, false);
-            var road4 = new Road(mPlatform, platform4, false);
-            var road5 = new Road(platform4, platform3, false);
+            
 
             // Resources
             var res = new Resource(EResourceType.Trash, platform2.Center);
@@ -114,17 +126,6 @@ namespace Singularity.Levels
             platform2.StoreResource(res4);
             platform2.StoreResource(res5);
 
-            //Finally add the objects
-            //GAMESCREEN=====================
-            mGameScreen.AddObject(mPlatform);
-            mGameScreen.AddObject(platform2);
-            mGameScreen.AddObject(platform3);
-            mGameScreen.AddObject(platform4);
-            mGameScreen.AddObject(road1);
-            mGameScreen.AddObject(road2);
-            mGameScreen.AddObject(road3);
-            mGameScreen.AddObject(road4);
-            mGameScreen.AddObject(road5);
             mGameScreen.AddObject(genUnit);
             mGameScreen.AddObject(genUnit2);
             mGameScreen.AddObject(genUnit3);
@@ -135,7 +136,7 @@ namespace Singularity.Levels
 
 
             //TESTMETHODS HERE =====================================
-            mDirector.GetDistributionManager.DistributeJobs(JobType.Idle, JobType.Production, 4);
+            mDirector.GetDistributionManager.DistributeJobs(JobType.Idle, JobType.Production, 5);
             mDirector.GetDistributionManager.TestAttributes();
 
         }

--- a/Singularity/Singularity/Platform/PlatformBlank.cs
+++ b/Singularity/Singularity/Platform/PlatformBlank.cs
@@ -23,6 +23,8 @@ namespace Singularity.Platform
 
     {
 
+        private int mGraphIndex;
+
         private float mLayer;
 
         /// <summary>
@@ -730,6 +732,32 @@ namespace Singularity.Platform
         public void SetLayer(float layer)
         {
             mLayer = layer;
+        }
+
+        public IEnumerable<INode> GetChilds()
+        {
+            var childs = new List<INode>();
+
+            foreach (var outgoing in GetOutwardsEdges())
+            {
+                childs.Add(outgoing.GetChild());
+            }
+
+            foreach (var ingoing in GetInwardsEdges())
+            {
+                childs.Add(ingoing.GetParent());
+            }
+            return childs;
+        }
+
+        public void SetGraphIndex(int graphIndex)
+        {
+            mGraphIndex = graphIndex;
+        }
+
+        public int GetGraphIndex()
+        {
+            return mGraphIndex;
         }
     }
 }

--- a/Singularity/Singularity/Platform/PlatformPlacement.cs
+++ b/Singularity/Singularity/Platform/PlatformPlacement.cs
@@ -180,7 +180,6 @@ namespace Singularity.Platform
                     // this case is the 'finish' state, we set everything up, so the platform can get added to the game
                     mPlatform.SetLayer(LayerConstants.PlatformLayer);
                     mConnectionRoad.Blueprint = false;
-                    mConnectionRoad.Place(mPlatform, mHoveringPlatform);
                     mIsFinished = true;
                     break;
 

--- a/Singularity/Singularity/Screen/HorizontalCollection.cs
+++ b/Singularity/Singularity/Screen/HorizontalCollection.cs
@@ -89,7 +89,6 @@ namespace Singularity.Screen
                 foreach (var item in mItemList)
                 {
                     item.Draw(spriteBatch);
-                    System.Diagnostics.Debug.WriteLine(item.Position);
                 }
             }
         }

--- a/Singularity/Singularity/Units/GeneralUnit.cs
+++ b/Singularity/Singularity/Units/GeneralUnit.cs
@@ -158,6 +158,7 @@ namespace Singularity.Units
         /// <param name="gametime"></param>
         public void Update(GameTime gametime)
         {
+
             switch (Job)
             {
                 case JobType.Idle:
@@ -225,7 +226,7 @@ namespace Singularity.Units
             // current nodequeue is empty (the path)
             if (mDestination.IsPresent() && mNodeQueue.Count <= 0 && !mIsMoving)
             {
-                mNodeQueue = mDirector.GetPathManager.GetPath(this, mDestination.Get()).GetNodePath();
+                mNodeQueue = mDirector.GetPathManager.GetPath(this, mDestination.Get(), ((PlatformBlank)mDestination.Get()).GetGraphIndex()).GetNodePath();
 
                 CurrentNode = mNodeQueue.Dequeue();
             }


### PR DESCRIPTION
- Multiple graphs are now supported by the structure map. The distribution might still fuck things up. One known bug is, if there are still production units available and a new production platform gets added to the second graph, the game will crash, since the distribution manager works on every platform in the game.

- Only added multiple graph support for AddPlatform and AddRoad functions, since of now we do not remove them.

- Need to make sure that platforms and roads get added instantly after creation, otherwise things will get out of sync (this is guaranteed in the actual game, but wasn't right now since we preadd alot of things)