### PR TITLE
Check comment. closes #364 and closes #271 and closes #266 and closes #269

### DIFF
--- a/Singularity/Singularity/Game1.cs
+++ b/Singularity/Singularity/Game1.cs
@@ -18,7 +18,6 @@ namespace Singularity
         // Screens
         private ILevel mLevel;
         private MainMenuManagerScreen mMainMenuManager;
-        private UserInterfaceScreen mUserInterfaceScreen;
 
         // Sprites!
         private SpriteBatch mSpriteBatch;
@@ -79,14 +78,10 @@ namespace Singularity
             mLevel = new Skirmish(mGraphics, ref mDirector, Content, mScreenManager);
 
             mMainMenuManager = new MainMenuManagerScreen(viewportResolution, mScreenManager, true, this);
-            // Add the screens to the screen manager
-            // The idea is that the game screen is always at the bottom and stuff is added simply
-            // on top of it.
             //ATTENTION: THE INGAME SCREENS ARE HANDLED IN THE LEVELS NOW!
             //mScreenManager.AddScreen(mMainMenuManager); // TODO: This makes it so that the main menu is bypassed
 
-            // load and play Soundtrack as background music
-            // todo this
+            // TODO: load and play Soundtrack as background music
             // director.GetSoundManager.LoadContent(Content);
             //_mSoundManager.PlaySoundTrack();
         }

--- a/Singularity/Singularity/Graph/Paths/DefaultPathfinding.cs
+++ b/Singularity/Singularity/Graph/Paths/DefaultPathfinding.cs
@@ -77,6 +77,11 @@ namespace Singularity.Graph.Paths
                 {
                     var neighbor = outgoing.GetChild();
 
+                    if (neighbor == null)
+                    {
+                        continue;
+                    }
+
                     if (closedList.Contains(neighbor))
                     {
                         continue;
@@ -101,6 +106,11 @@ namespace Singularity.Graph.Paths
                 foreach (var outgoing in current.GetInwardsEdges())
                 {
                     var neighbor = outgoing.GetParent();
+
+                    if (neighbor == null)
+                    {
+                        continue;
+                    }
 
                     if (closedList.Contains(neighbor))
                     {

--- a/Singularity/Singularity/Levels/Skirmish.cs
+++ b/Singularity/Singularity/Levels/Skirmish.cs
@@ -144,7 +144,6 @@ namespace Singularity.Levels
             GameScreen.AddObject(milUnit);
             GameScreen.AddObject(setUnit);
 
-
             //TESTMETHODS HERE ====================================
             mDirector.GetDistributionManager.RequestResource(platform2, EResourceType.Oil, null);
         }

--- a/Singularity/Singularity/Levels/Skirmish.cs
+++ b/Singularity/Singularity/Levels/Skirmish.cs
@@ -65,7 +65,7 @@ namespace Singularity.Levels
             //Map related stuff
             mCamera = new Camera(mGraphics.GraphicsDevice, ref mDirector, 800, 800);
             mFow = new FogOfWar(mCamera, mGraphics.GraphicsDevice);
-            mMap = new Map.Map(mapBackground, 20, 20, mFow, mGraphics.GraphicsDevice.Viewport, ref mDirector); // NEOLAYOUT (searchmark for @fkarg)
+            mMap = new Map.Map(mapBackground, 20, 20, mFow, mCamera, ref mDirector); // NEOLAYOUT (searchmark for @fkarg)
 
             //INITIALIZE SCREENS AND ADD THEM TO THE SCREENMANAGER
             GameScreen = new GameScreen(mGraphics.GraphicsDevice, ref mDirector, mMap, mCamera, mFow);

--- a/Singularity/Singularity/Levels/Skirmish.cs
+++ b/Singularity/Singularity/Levels/Skirmish.cs
@@ -67,9 +67,9 @@ namespace Singularity.Levels
             PlatformFactory.Init(null, platformCylTexture, platformDomeTexture, platformBlankTexture);
 
             //Map related stuff
-            mCamera = new Camera(mGraphics.GraphicsDevice, ref mDirector, 800, 800);
-            mFow = new FogOfWar(mCamera, mGraphics.GraphicsDevice);
-            mMap = new Map.Map(mapBackground, 20, 20, mFow, mCamera, ref mDirector); // NEOLAYOUT (searchmark for @fkarg)
+            Camera = new Camera(mGraphics.GraphicsDevice, ref mDirector, 800, 800);
+            mFow = new FogOfWar(Camera, mGraphics.GraphicsDevice);
+            Map = new Map.Map(mapBackground, 20, 20, mFow, Camera, ref mDirector); // NEOLAYOUT (searchmark for @fkarg)
 
             //INITIALIZE SCREENS AND ADD THEM TO THE SCREENMANAGER
             GameScreen = new GameScreen(mGraphics.GraphicsDevice, ref mDirector, Map, Camera, mFow);

--- a/Singularity/Singularity/Levels/Tutorial.cs
+++ b/Singularity/Singularity/Levels/Tutorial.cs
@@ -65,9 +65,9 @@ namespace Singularity.Levels
             PlatformFactory.Init(null, platformCylTexture, platformDomeTexture, platformBlankTexture);
 
             //Map related stuff
-            mCamera = new Camera(mGraphics.GraphicsDevice, ref mDirector, 800, 800);
-            mFow = new FogOfWar(mCamera, mGraphics.GraphicsDevice);
-            mMap = new Map.Map(mapBackground, 20, 20, mFow, mCamera, ref mDirector); // NEOLAYOUT (searchmark for @fkarg)
+            Camera = new Camera(mGraphics.GraphicsDevice, ref mDirector, 800, 800);
+            mFow = new FogOfWar(Camera, mGraphics.GraphicsDevice);
+            Map = new Map.Map(mapBackground, 20, 20, mFow, Camera, ref mDirector); // NEOLAYOUT (searchmark for @fkarg)
 
             //INITIALIZE SCREENS AND ADD THEM
             GameScreen = new GameScreen(mGraphics.GraphicsDevice, ref mDirector, Map, Camera, mFow);

--- a/Singularity/Singularity/Levels/Tutorial.cs
+++ b/Singularity/Singularity/Levels/Tutorial.cs
@@ -62,7 +62,7 @@ namespace Singularity.Levels
             //Map related stuff
             mCamera = new Camera(mGraphics.GraphicsDevice, ref mDirector, 800, 800);
             mFow = new FogOfWar(mCamera, mGraphics.GraphicsDevice);
-            mMap = new Map.Map(mapBackground, 20, 20, mFow, mGraphics.GraphicsDevice.Viewport, ref mDirector); // NEOLAYOUT (searchmark for @fkarg)
+            mMap = new Map.Map(mapBackground, 20, 20, mFow, mCamera, ref mDirector); // NEOLAYOUT (searchmark for @fkarg)
 
             //INITIALIZE SCREENS AND ADD THEM
             GameScreen = new GameScreen(mGraphics.GraphicsDevice, ref mDirector, mMap, mCamera, mFow);

--- a/Singularity/Singularity/Map/Camera.cs
+++ b/Singularity/Singularity/Map/Camera.cs
@@ -113,7 +113,6 @@ namespace Singularity.Map
 
         public void Update(GameTime gametime)
         {
-
             //finally update the matrix to all the fitting values.
             UpdateTransformMatrix();
         }
@@ -338,6 +337,24 @@ namespace Singularity.Map
         {
             mMouseX = screenX;
             mMouseY = screenY;
+        }
+
+        public Vector2 GetRelativePosition()
+        {
+            return Vector2.Transform(Vector2.Zero, Matrix.Invert(mTransform));
+        }
+
+        public void SetPosition(Vector2 position)
+        {
+            mX = position.X;
+            mY = position.Y;
+
+            ValidatePosition();
+        }
+
+        public Vector2 GetSize()
+        {
+            return new Vector2(mGraphics.Viewport.Width, mGraphics.Viewport.Height) / mZoom;
         }
     }
 }

--- a/Singularity/Singularity/Map/Camera.cs
+++ b/Singularity/Singularity/Map/Camera.cs
@@ -70,7 +70,7 @@ namespace Singularity.Map
         /// <param name="x">The initial x position of the camera</param>
         /// <param name="y">the initial y position of the camera</param>
         /// <param name="neo">If the neo Layout should be used for navigating instead of qwertz</param>
-        public Camera(GraphicsDevice graphics, ref Director director, int x = 0, int y = 0, bool neo = true)
+        public Camera(GraphicsDevice graphics, ref Director director, int x = 0, int y = 0, bool neo = false)
         {
 
             if (x < 0)

--- a/Singularity/Singularity/Map/FogOfWar.cs
+++ b/Singularity/Singularity/Map/FogOfWar.cs
@@ -33,11 +33,6 @@ namespace Singularity.Map
     {
 
         /// <summary>
-        /// This array holds bit values of whether the position (tile) was visited or not. Where 1 = visited and 0 = unvisited.
-        /// </summary>
-        private bool[,] mToDraw;
-
-        /// <summary>
         /// A list of all the objects which are able to reveal the fog of war.
         /// </summary>
         private readonly LinkedList<IRevealing> mRevealingObjects;

--- a/Singularity/Singularity/Map/StructureMap.cs
+++ b/Singularity/Singularity/Map/StructureMap.cs
@@ -228,6 +228,17 @@ namespace Singularity.Map
                     continue;
                 }
 
+                foreach(var platformToAdd in mPlatformsToPlace)
+                {
+                    platformToAdd.GetPlatform().UpdateValues();
+                    if (!platformToAdd.GetPlatform().AbsBounds.Intersects(platform.AbsBounds))
+                    {
+                        continue;
+                    }
+                    hovering = platform;
+
+                }
+
                 if (!platform.AbsBounds.Intersects(new Rectangle((int) mMouseX, (int) mMouseY, 1, 1)))
                 {
                     continue;
@@ -249,6 +260,7 @@ namespace Singularity.Map
 
                 if (!platformToAdd.IsFinished())
                 {
+
                     platformToAdd.SetHovering(hovering);
                     platformToAdd.Update(gametime);
                     continue;

--- a/Singularity/Singularity/Map/StructureMap.cs
+++ b/Singularity/Singularity/Map/StructureMap.cs
@@ -246,18 +246,28 @@ namespace Singularity.Map
 
             foreach (var platformToAdd in mPlatformsToPlace)
             {
+
                 if (!platformToAdd.IsFinished())
                 {
                     platformToAdd.SetHovering(hovering);
                     platformToAdd.Update(gametime);
-                    return;
+                    continue;
                 }
+                if (platformToAdd.IsCanceled())
+                {
+                    platformToAdd.Update(gametime);
+                    toRemove.AddLast(platformToAdd);
+                    continue;
+                }
+
                 //platform is finished
+                toRemove.AddLast(platformToAdd);
+
                 AddPlatform(platformToAdd.GetPlatform());
                 platformToAdd.GetPlatform().Register();
                 platformToAdd.GetRoad().Place(platformToAdd.GetPlatform(), hovering);
                 AddRoad(platformToAdd.GetRoad());
-                toRemove.AddLast(platformToAdd);
+
             }
 
             foreach(var platformToRemove in toRemove)

--- a/Singularity/Singularity/Platforms/PlatformBlank.cs
+++ b/Singularity/Singularity/Platforms/PlatformBlank.cs
@@ -510,14 +510,17 @@ namespace Singularity.Platforms
 
         }
 
-        public void RemoveEdge(IEdge edge, EEdgeFacing facing)
+        public void RemoveEdge(IEdge edge)
         {
-            if (facing == EEdgeFacing.Inwards)
+            if (mInwardsEdges.Contains(edge))
             {
                 mInwardsEdges.Remove(edge);
-                return;
             }
-            mOutwardsEdges.Remove(edge);
+
+            if (mOutwardsEdges.Contains(edge))
+            {
+                mOutwardsEdges.Remove(edge);
+            }
 
         }
 

--- a/Singularity/Singularity/Platforms/PlatformFactory.cs
+++ b/Singularity/Singularity/Platforms/PlatformFactory.cs
@@ -19,8 +19,6 @@ namespace Singularity.Platforms
 
         private static Texture2D sBlankSheet;
 
-        private static Director sDirector;
-
         /// <summary>
         /// Initializes the platform factory with the sprite sheets needed.
         /// </summary>

--- a/Singularity/Singularity/Platforms/PlatformPlacement.cs
+++ b/Singularity/Singularity/Platforms/PlatformPlacement.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using System.Diagnostics;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Singularity.Input;
 using Singularity.Manager;
@@ -61,6 +62,8 @@ namespace Singularity.Platforms
         /// </summary>
         private float mMouseY;
 
+        private bool mCanceled;
+
         private readonly Camera mCamera;
 
         private readonly bool mSettler;
@@ -69,8 +72,12 @@ namespace Singularity.Platforms
 
         private readonly Director mDirector;
 
+        private bool mUnregister;
+
         public PlatformPlacement(EPlatformType platformType, EPlacementType placementType, EScreen screen, Camera camera, ref Director director, float x = 0, float y = 0, ResourceMap resourceMap = null, bool settler = false, Vector2 position = default(Vector2))
         {
+            mUnregister = false;
+
             mCamera = camera;
             Screen = screen;
             mDirector = director;
@@ -177,11 +184,19 @@ namespace Singularity.Platforms
                     mPlatform.SetLayer(LayerConstants.PlatformLayer);
                     mConnectionRoad.Blueprint = false;
                     mIsFinished = true;
+                    mUnregister = true;
                     break;
 
                 default:
                     break;
             }
+
+            if (mUnregister)
+            {
+                Debug.WriteLine("unregister");
+                UnregisterFromInputManager();
+            }
+
             // don't forget to always update the relative position since the camera might have moved.
             UpdateBounds();
         }
@@ -244,12 +259,15 @@ namespace Singularity.Platforms
 
             if (mouseAction == EMouseAction.RightClick)
             {
-                /* The guess was that this is sufficient to stop placing Platforms. Turns out it isn't, additionally there'll be a nullPointer happening for a Road somewhere.
                 if (mCurrentState.GetState() == 1)
                 {
+                    mCanceled = true;
                     mIsFinished = true;
+                    giveThrough = false;
+                    mUnregister = true;
+
+                    return giveThrough;
                 }
-                */
 
                 // we only need to do something with rightclick if were in the 2nd state, since then we revert.
                 if (mCurrentState.GetState() != 2)
@@ -319,6 +337,17 @@ namespace Singularity.Platforms
         public Road GetRoad()
         {
             return mConnectionRoad;
+        }
+
+        public bool IsCanceled()
+        {
+            return mCanceled;
+        }
+
+        private void UnregisterFromInputManager()
+        {
+            mDirector.GetInputManager.RemoveMouseClickListener(this);
+            mDirector.GetInputManager.RemoveMousePositionListener(this);
         }
     }
 }

--- a/Singularity/Singularity/Platforms/PlatformPlacement.cs
+++ b/Singularity/Singularity/Platforms/PlatformPlacement.cs
@@ -66,15 +66,11 @@ namespace Singularity.Platforms
 
         private readonly Camera mCamera;
 
-        private readonly bool mSettler;
-
-        private readonly Vector2 mSetPosition;
-
         private readonly Director mDirector;
 
         private bool mUnregister;
 
-        public PlatformPlacement(EPlatformType platformType, EPlacementType placementType, EScreen screen, Camera camera, ref Director director, float x = 0, float y = 0, ResourceMap resourceMap = null, bool settler = false, Vector2 position = default(Vector2))
+        public PlatformPlacement(EPlatformType platformType, EPlacementType placementType, EScreen screen, Camera camera, ref Director director, float x = 0, float y = 0, ResourceMap resourceMap = null, Vector2 position = default(Vector2))
         {
             mUnregister = false;
 
@@ -84,9 +80,6 @@ namespace Singularity.Platforms
 
             mDirector.GetInputManager.AddMouseClickListener(this, EClickType.Both, EClickType.Both);
             mDirector.GetInputManager.AddMousePositionListener(this);
-
-            mSettler = settler;
-            mSetPosition = position;
 
             // for further information as to why which states refer to the documentation for mCurrentState
             switch (placementType)
@@ -142,17 +135,16 @@ namespace Singularity.Platforms
             switch (mCurrentState.GetState())
             {
                 case 1:
+                    mPlatform.ResetColor();
                     // for this, we want the platform to follow the mouse, and also be centered on the sprite.
-                    if (!mSettler)
+                    mPlatform.AbsolutePosition = new Vector2(mMouseX - mPlatform.AbsoluteSize.X / 2f,
+                        mMouseY - mPlatform.AbsoluteSize.Y / 2f);
+
+                    if (mHoveringPlatform == null)
                     {
-                        mPlatform.AbsolutePosition = new Vector2(mMouseX - mPlatform.AbsoluteSize.X / 2f,
-                            mMouseY - mPlatform.AbsoluteSize.Y / 2f);
+                        break;
                     }
-                    else
-                    {
-                        mPlatform.AbsolutePosition = new Vector2(mSetPosition.X - mPlatform.AbsoluteSize.X / 2f,
-                            mSetPosition.Y - mPlatform.AbsoluteSize.Y / 2f);
-                    }
+                    mPlatform.SetColor(Color.Red);
 
                     break;
 
@@ -193,7 +185,6 @@ namespace Singularity.Platforms
 
             if (mUnregister)
             {
-                Debug.WriteLine("unregister");
                 UnregisterFromInputManager();
             }
 
@@ -214,7 +205,7 @@ namespace Singularity.Platforms
                         mPlatform.UpdateValues();
 
                         //first check if the platform is even on the map, if not we don't want to progress, since it isn't a valid position
-                        if (!Map.Map.IsOnTop(mPlatform.AbsBounds))
+                        if (!Map.Map.IsOnTop(mPlatform.AbsBounds) || mHoveringPlatform != null)
                         {
                             break;
                         }

--- a/Singularity/Singularity/Platforms/Road.cs
+++ b/Singularity/Singularity/Platforms/Road.cs
@@ -12,9 +12,9 @@ namespace Singularity.Platforms
 
         public Vector2 Destination { get; set; }
 
-        private INode SourceAsNode { get; set; }
+        public INode SourceAsNode { get; set; }
 
-        private INode DestinationAsNode { get; set; }
+        public INode DestinationAsNode { get; set; }
 
         private bool mBlueprint;
 

--- a/Singularity/Singularity/Property/GlobalVariables.cs
+++ b/Singularity/Singularity/Property/GlobalVariables.cs
@@ -5,7 +5,7 @@
         /// <summary>
         /// Indicates whether the game is in debug mode or not
         /// </summary>
-        internal static bool DebugState { get; set; } = true;
+        internal static bool DebugState { get; set; } = false;
 
     }
 }

--- a/Singularity/Singularity/Screen/Button.cs
+++ b/Singularity/Singularity/Screen/Button.cs
@@ -77,6 +77,7 @@ namespace Singularity.Screen
             CreateRectangularBounds();
             Opacity = 1;
             ActiveWindow = true;
+            mWithBorder = withBorder;
         }
 
 
@@ -101,6 +102,7 @@ namespace Singularity.Screen
             CreateRectangularBounds();
             Opacity = 1;
             ActiveWindow = true;
+            mWithBorder = withBorder;
         }
 
 

--- a/Singularity/Singularity/Screen/ScreenClasses/GameScreen.cs
+++ b/Singularity/Singularity/Screen/ScreenClasses/GameScreen.cs
@@ -123,6 +123,12 @@ namespace Singularity.Screen.ScreenClasses
 
         public void Update(GameTime gametime)
         {
+
+            foreach (var updateable in mUpdateables)
+            {
+                updateable.Update(gametime);
+            }
+
             foreach (var spatial in mSpatialObjects.Concat(mMap.GetStructureMap().GetPlatformList()))
             {
                 var collidingObject = spatial as ICollider;
@@ -142,14 +148,10 @@ namespace Singularity.Screen.ScreenClasses
             mFow.Update(gametime);
 
             mTransformMatrix = mCamera.GetTransform();
-
-            // TODO: for some reason just adding to GameScreen in constructor does NOT call up Update method
-            mSelBox.Update(gametime);
         }
 
         public void LoadContent(ContentManager content)
         {
-
             AddObject(mMap);
 
             AddObjects(ResourceHelper.GetRandomlyDistributedResources(5));


### PR DESCRIPTION
- Made the tiles of the map only get drawn in its viewport

- fixed a "bug" where the selection box wouldn't get updated automatically

- Made the platform building be "cancelable" with right click

- Made it impossible for platforms to be placed ontop of other platforms

- removed some warnings

- Thoroughly documented the structure map

- Added graph synchronization for the RemoveRoad method

  - tested with RemoveRoad and works (atleast with idle distribution)

  - also somewhat added it for the RemovePlatform method. I had no idea how to efficiently do it, since it possibly can create n new graphs. I did it in such a way that the idle distribution works, since that doesn't depend on the graphs. As soons as pathfinding gets applied things might get weird (treated as if the platform wasn't removed).

