### PR TITLE
DefensePlatforms now correctly show the texture when they die

### DIFF
--- a/Singularity/Singularity/Platforms/DefenseBase.cs
+++ b/Singularity/Singularity/Platforms/DefenseBase.cs
@@ -73,7 +73,7 @@ namespace Singularity.Platforms
             // Cone (Defense Platforms)
             // Draw the basic platform first
             spriteBatch.Draw(mPlatformBaseTexture,
-                Vector2.Add(AbsolutePosition, new Vector2(0, 78)),
+                Vector2.Add(AbsolutePosition, new Vector2(0, mType == EStructureType.Blank ? 0 : 78)),
                 null,
                 mColorBase * transparency,
                 0f,
@@ -81,6 +81,7 @@ namespace Singularity.Platforms
                 1f,
                 SpriteEffects.None,
                 LayerConstants.BasePlatformLayer);
+            if (mType == EStructureType.Blank) return;
             // then draw what's on top of that
             spriteBatch.Draw(mPlatformSpriteSheet,
                 AbsolutePosition,


### PR DESCRIPTION
The LaserDefenseBase still requires Energy however