### PR TITLE
Implementation of the DeathManager

### DIFF
--- a/Singularity/Singularity/Game1.cs
+++ b/Singularity/Singularity/Game1.cs
@@ -117,6 +117,9 @@ namespace Singularity
             mDirector.Update(gameTime, IsActive);
             mScreenManager.Update(gameTime);
 
+            // make sure this is ALWAYS the last call in our update cycle otherwise things might get nasty.
+            mDirector.GetDeathManager.KillAddedObjects();
+
             base.Update(gameTime);
         }
 

--- a/Singularity/Singularity/Manager/DeathManager.cs
+++ b/Singularity/Singularity/Manager/DeathManager.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Singularity.Property;
+using Singularity.Utils;
+
+namespace Singularity.Manager
+{
+    public sealed class DeathManager
+    {
+        private readonly SortedList<int, IDie> mToKill;
+
+        public DeathManager()
+        {
+            mToKill = new SortedList<int, IDie>(new AscendingIntegerComparer());
+        }
+
+        public void AddToKill(IDie objectToKill)
+        {
+            mToKill.Add(objectToKill.DeathOrder, objectToKill);
+        }
+
+        public void KillAddedObjects()
+        {
+            if (mToKill.Count <= 0)
+            {
+                return;
+            }
+
+            foreach (var objectToKill in mToKill.Values)
+            {
+                objectToKill.Die();
+            }
+            mToKill.Clear();
+        }
+    }
+}

--- a/Singularity/Singularity/Manager/Director.cs
+++ b/Singularity/Singularity/Manager/Director.cs
@@ -39,6 +39,9 @@ namespace Singularity.Manager
         [DataMember]
         public UserInterfaceController GetUserInterfaceController { get; private set; }
 
+        [DataMember]
+        public DeathManager GetDeathManager { get; private set; }
+
         public GraphicsDeviceManager GetGraphicsDeviceManager { get; }
 
         public EventLog GetEventLog { get; }
@@ -57,6 +60,7 @@ namespace Singularity.Manager
                                                         // (like units telling it they exist and the like)
             GetEventLog = new EventLog(GetUserInterfaceController, this, content);
             GetGraphicsDeviceManager = graphics;
+            GetDeathManager = new DeathManager();
 
             GetSoundManager.LoadContent(content);
             GetSoundManager.PlaySoundTrack();

--- a/Singularity/Singularity/Nature/Puddle.cs
+++ b/Singularity/Singularity/Nature/Puddle.cs
@@ -9,7 +9,7 @@ using Singularity.Property;
 namespace Singularity.Nature
 {
     [DataContract]
-    public class Puddle : ICollider
+    public class Puddle : ADie, ICollider
     {
         public bool[,] ColliderGrid { get; internal set; }
 
@@ -36,7 +36,7 @@ namespace Singularity.Nature
         [DataMember]
         public bool Friendly { get; private set; }
 
-        public Puddle(Vector2 position, ref Director director, bool bigPuddle = true)
+        public Puddle(Vector2 position, ref Director director, bool bigPuddle = true) : base(ref director)
         {
             Id = director.GetIdGenerator.NextiD();
             AbsoluteSize = new Vector2(160, 130);
@@ -158,7 +158,7 @@ namespace Singularity.Nature
             // do nothing
         }
 
-        public bool Die()
+        public override bool Die()
         {
             throw new NotImplementedException();
         }

--- a/Singularity/Singularity/Nature/Rock.cs
+++ b/Singularity/Singularity/Nature/Rock.cs
@@ -9,7 +9,7 @@ using Singularity.Property;
 namespace Singularity.Nature
 {
     [DataContract]
-    public class Rock : ICollider
+    public class Rock : ADie, ICollider
     {
         public bool[,] ColliderGrid { get; internal set; }
 
@@ -46,7 +46,7 @@ namespace Singularity.Nature
         [DataMember]
         public Vector2 Center { get; private set; }
 
-        public Rock(Vector2 position, ref Director director)
+        public Rock(Vector2 position, ref Director director) : base(ref director)
         {
             Id = director.GetIdGenerator.NextiD();
             AbsoluteSize = new Vector2(160, 130);
@@ -258,7 +258,7 @@ namespace Singularity.Nature
             // do nothing
         }
 
-        public bool Die()
+        public override bool Die()
         {
             throw new NotImplementedException();
         }

--- a/Singularity/Singularity/Platforms/PlatformBlank.cs
+++ b/Singularity/Singularity/Platforms/PlatformBlank.cs
@@ -26,7 +26,7 @@ namespace Singularity.Platforms
     /// <inheritdoc cref="ICollider"/>
     /// <inheritdoc cref="IDamageable"/>
     [DataContract]
-    public class PlatformBlank : IRevealing, INode, ICollider, IMouseClickListener
+    public class PlatformBlank : ADie, IRevealing, INode, ICollider, IMouseClickListener
     {
         #region private
 
@@ -224,7 +224,7 @@ namespace Singularity.Platforms
 
         protected int mPowerDownSoundId;
 
-        public PlatformBlank(Vector2 position, Texture2D platformSpriteSheet, Texture2D baseSprite, SpriteFont libsans12, ref Director director, EStructureType type = EStructureType.Blank, float centerOffsetY = -36, bool friendly = true)
+        public PlatformBlank(Vector2 position, Texture2D platformSpriteSheet, Texture2D baseSprite, SpriteFont libsans12, ref Director director, EStructureType type = EStructureType.Blank, float centerOffsetY = -36, bool friendly = true) : base(ref director)
         {
 
             mPrevPlatformActions = new List<IPlatformAction>();
@@ -543,7 +543,7 @@ namespace Singularity.Platforms
             {
                 if (mType == EStructureType.Blank)
                 {
-                    Die();
+                    FlagForDeath();
                 }
                 else
                 {
@@ -1074,7 +1074,7 @@ namespace Singularity.Platforms
             mDirector.GetMilitaryManager.AddUnit(this);
         }
 
-        public bool Die()
+        public override bool Die()
         {
             // stats tracking for a platform death
             mDirector.GetStoryManager.UpdatePlatforms(Friendly ? "lost" : "destroyed");

--- a/Singularity/Singularity/Platforms/Road.cs
+++ b/Singularity/Singularity/Platforms/Road.cs
@@ -11,7 +11,7 @@ using System.Diagnostics;
 namespace Singularity.Platforms
 {
     [DataContract]
-    public sealed class Road : ISpatial, IEdge
+    public sealed class Road : ADie, ISpatial, IEdge
     {
         [DataMember]
         public Vector2 Source { get; set; }
@@ -55,7 +55,7 @@ namespace Singularity.Platforms
         /// <param name="source">The source IRevealing object from which this road gets drawn</param>
         /// <param name="destination">The destinaion IRevealing object to which this road gets drawn</param>
         /// <param name="blueprint">Whether this road is a blueprint or not</param>
-        public Road(PlatformBlank source, PlatformBlank destination, ref Director director, bool blueprint = false)
+        public Road(PlatformBlank source, PlatformBlank destination, ref Director director, bool blueprint = false) : base(ref director)
         {
 
             // the hardcoded values need some changes for different platforms, ill wait until those are implemented to find a good solution.
@@ -130,7 +130,7 @@ namespace Singularity.Platforms
             return Vector2.Distance(Source, Destination);
         }
 
-        public bool Die()
+        public override bool Die()
         {
             mDirector.GetStoryManager.Level.GameScreen.RemoveObject(this);
             return true;

--- a/Singularity/Singularity/Property/ADie.cs
+++ b/Singularity/Singularity/Property/ADie.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Singularity.Manager;
+
+namespace Singularity.Property
+{
+    public abstract class ADie : IDie
+    {
+        private Director mDirector;
+
+        protected ADie(ref Director director)
+        {
+            mDirector = director;
+        }
+
+        public int DeathOrder { get; protected set; } = 0;
+
+        public abstract bool Die();
+
+        public bool FlagForDeath()
+        {
+            mDirector.GetDeathManager.AddToKill(this);
+            return true;
+        }
+    }
+}

--- a/Singularity/Singularity/Property/IDie.cs
+++ b/Singularity/Singularity/Property/IDie.cs
@@ -3,6 +3,18 @@
     public interface IDie
     {
         /// <summary>
+        /// An integer showing when to let this die in comparision to all the other IDie implementations. Where 0 is first and the higher
+        /// the int the later it dies.
+        /// </summary>
+        int DeathOrder { get; }
+
+        /// <summary>
+        /// Flags this object to die, being removed specified by its order at the end of the update cycle by the DeathManager.
+        /// </summary>
+        /// <returns></returns>
+        bool FlagForDeath();
+
+        /// <summary>
         /// Letting object 'Die', by removing all it's references from other things
         /// </summary>
         bool Die();

--- a/Singularity/Singularity/Resources/MapResource.cs
+++ b/Singularity/Singularity/Resources/MapResource.cs
@@ -15,7 +15,7 @@ namespace Singularity.Resources
     /// Represents a resource-field on the Map in the game. Resources can be extraced from it using the Well, the Mine or the Quarry.
     /// </summary>
     [DataContract]
-    public sealed class MapResource : ISpatial
+    public sealed class MapResource : ADie, ISpatial
     {
         private Director mDirector;
 
@@ -45,7 +45,7 @@ namespace Singularity.Resources
         /// <param name="position">The inital position for this resource</param>
         /// <param name="width">The width of the resource on screen</param>
         /// /// <param name="director">Director of the game.</param>
-        public MapResource(EResourceType type, Vector2 position, int width, ref Director director)
+        public MapResource(EResourceType type, Vector2 position, int width, ref Director director) : base(ref director)
         {
             Type = type;
             AbsolutePosition = position;
@@ -82,7 +82,7 @@ namespace Singularity.Resources
             // There is no update code.
         }
 
-        public bool Die()
+        public override bool Die()
         {
             return true;
         }

--- a/Singularity/Singularity/Resources/Resource.cs
+++ b/Singularity/Singularity/Resources/Resource.cs
@@ -10,7 +10,7 @@ using Singularity.Utils;
 namespace Singularity.Resources
 {
     [DataContract]
-    public class Resource : ISpatial
+    public class Resource : ADie, ISpatial
     {
         // TODO: fkarg implement
         [DataMember]
@@ -31,7 +31,7 @@ namespace Singularity.Resources
         [DataMember]
         private Optional<GeneralUnit> mFollowing;
 
-        public Resource(EResourceType type, Vector2 position, Director director)
+        public Resource(EResourceType type, Vector2 position, Director director) : base(ref director)
         {
             Type = type;
             AbsolutePosition = position;
@@ -95,7 +95,7 @@ namespace Singularity.Resources
             mVelocity = Vector2.Multiply(mVelocity, 0.8f);
         }
 
-        public bool Die()
+        public override bool Die()
         {
             UnFollow();
             return true;

--- a/Singularity/Singularity/Singularity.csproj
+++ b/Singularity/Singularity/Singularity.csproj
@@ -71,11 +71,13 @@
     <Compile Include="AI\Structures\Spawner.cs" />
     <Compile Include="Levels\PlatformDestructionTestLevel.cs" />
     <Compile Include="Events\SpatialPositionEventArgs.cs" />
+    <Compile Include="Manager\DeathManager.cs" />
     <Compile Include="Nature\Rock.cs" />
     <Compile Include="Levels\BasicLevel.cs" />
     <Compile Include="Levels\ILevel.cs" />
     <Compile Include="Manager\DistributionDirector.cs" />
     <Compile Include="Manager\DistributionManager.cs" />
+    <Compile Include="Property\ADie.cs" />
     <Compile Include="Screen\Checkbox.cs" />
     <Compile Include="PlatformActions\RefineResourceAction.cs" />
     <Compile Include="Screen\ELogEventType.cs" />
@@ -224,6 +226,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Screen\UserInterfaceController.cs" />
+    <Compile Include="Utils\AscendingIntegerComparer.cs" />
     <Compile Include="Utils\Clock.cs" />
     <Compile Include="Utils\State3.cs" />
     <Compile Include="Utils\Geometry.cs" />

--- a/Singularity/Singularity/Units/FreeMovingUnit.cs
+++ b/Singularity/Singularity/Units/FreeMovingUnit.cs
@@ -17,7 +17,7 @@ namespace Singularity.Units
     /// <inheritdoc cref="ICollider"/>
     /// <inheritdoc cref="IRevealing"/>
     [DataContract]
-    internal abstract class FreeMovingUnit : ICollider, IRevealing, IMouseClickListener, IMousePositionListener
+    internal abstract class FreeMovingUnit : ADie, ICollider, IRevealing, IMouseClickListener, IMousePositionListener
     {
         /// <summary>
         /// The unique ID of the unit.
@@ -220,7 +220,7 @@ namespace Singularity.Units
         /// map, and implements pathfinding for objects on the map. It also allows subclasses to have
         /// health and to be damaged.
         /// </remarks>
-        protected FreeMovingUnit(Vector2 position, Camera camera, ref Director director, ref Map.Map map, bool friendly = true)
+        protected FreeMovingUnit(Vector2 position, Camera camera, ref Director director, ref Map.Map map, bool friendly = true) : base(ref director)
         {
             Id = director.GetIdGenerator.NextiD(); // id for the specific unit.
 
@@ -423,11 +423,11 @@ namespace Singularity.Units
             Health -= damage;
             if (Health <= 0 && !HasDieded)
             {
-                Die();
+                FlagForDeath();
             }
         }
 
-        public virtual bool Die()
+        public override bool Die()
         {
             HasDieded = true;
             // stats tracking for the death of any free moving unit

--- a/Singularity/Singularity/Units/GeneralUnit.cs
+++ b/Singularity/Singularity/Units/GeneralUnit.cs
@@ -14,7 +14,7 @@ using Singularity.Utils;
 namespace Singularity.Units
 {
     [DataContract]
-    public sealed class GeneralUnit : ISpatial
+    public sealed class GeneralUnit : ADie, ISpatial
     {
         [DataMember]
         public int Id { get; private set; }
@@ -104,7 +104,7 @@ namespace Singularity.Units
         [DataMember]
         public bool Active { get; set; }
 
-        public GeneralUnit(PlatformBlank platform, ref Director director)
+        public GeneralUnit(PlatformBlank platform, ref Director director) : base(ref director)
         {
             Graphid = platform.GetGraphIndex();
             platform.AddGeneralUnit(this);
@@ -532,7 +532,7 @@ namespace Singularity.Units
             }
         }
 
-        public bool Die()
+        public override bool Die()
         {
             // stats tracking for the death of a general unit
             mDirector.GetStoryManager.UpdateUnits("lost");

--- a/Singularity/Singularity/Utils/AscendingIntegerComparer.cs
+++ b/Singularity/Singularity/Utils/AscendingIntegerComparer.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Singularity.Utils
+{
+    /// <summary>
+    /// This is probably the default comparator for ints, but might aswell, so I definitely know that it does sort by ascending.
+    /// </summary>
+    public sealed class AscendingIntegerComparer : IComparer<int>
+    {
+        public int Compare(int x, int y)
+        {
+            if (x < y)
+            {
+                return -1;
+            }
+
+            return x > y ? 1 : 0;
+        }
+    }
+}


### PR DESCRIPTION
- Implementation of the DeathManager. This works, but I might have forg…otten to change a Die() call to a FlagForDeath() call. The idea is for Die() to only be called in Die() itself. (for example the platform kills its resources itself, which itself defines an ordering on how to kill stuff). Every Die() call outside of Die() should NOT exists, except for the DeathManager.

- Note i have NOT defined a ordering on the IDie implementations since I don't know in what order they should Die. For now I've made them Die() in the order they get added that update cycle.