### PR TITLE
Made it such that only defense and production platforms get reregiste…

### DIFF
--- a/Singularity/Singularity/Platforms/PlatformBlank.cs
+++ b/Singularity/Singularity/Platforms/PlatformBlank.cs
@@ -1283,7 +1283,7 @@ namespace Singularity.Platforms
             }
             ResetColor();
             //Only reregister the platforms if they are defense or production platforms
-            if (!mIsActive)
+            if (!mIsActive && (IsProduction() || IsDefense()))
             {
                 mDirector.GetDistributionDirector.GetManager(GetGraphIndex()).Register(this);
             }


### PR DESCRIPTION
…red as stated in the comment. This fixes some bugs (formerly every platform reregistered itself if it got activated again even if it was a blank or a cc)