### PR TITLE
Fixed issue where full screen would override resolution options

### DIFF
--- a/Singularity/Singularity/Game1.cs
+++ b/Singularity/Singularity/Game1.cs
@@ -69,8 +69,18 @@ namespace Singularity
             IsMouseVisible = true;
             mGraphics.PreferredDepthStencilFormat = DepthFormat.Depth24Stencil8;
 
-            mGraphics.PreferredBackBufferWidth = GlobalVariables.ResolutionList[GlobalVariables.ChosenResolution].Item1;
-            mGraphics.PreferredBackBufferHeight = GlobalVariables.ResolutionList[GlobalVariables.ChosenResolution].Item2;
+            if (GlobalVariables.IsFullScreen)
+            {
+                mGraphics.PreferredBackBufferWidth = mGraphicsAdapter.CurrentDisplayMode.Width;
+                mGraphics.PreferredBackBufferHeight = mGraphicsAdapter.CurrentDisplayMode.Height;
+            }
+            else
+            {
+
+                mGraphics.PreferredBackBufferWidth = GlobalVariables.ResolutionList[GlobalVariables.ChosenResolution].Item1;
+                mGraphics.PreferredBackBufferHeight = GlobalVariables.ResolutionList[GlobalVariables.ChosenResolution].Item2;
+            }
+
             mGraphics.IsFullScreen = GlobalVariables.IsFullScreen;
 
             mGraphics.ApplyChanges();

--- a/Singularity/Singularity/Screen/ScreenClasses/LoseScreen.cs
+++ b/Singularity/Singularity/Screen/ScreenClasses/LoseScreen.cs
@@ -193,6 +193,7 @@ namespace Singularity.Screen.ScreenClasses
 
         private void ReturnToMainMenu(object sender, EventArgs eventArgs)
         {
+            mDirector.GetStoryManager.Level.GameScreen.Unload();
             for (var i = 0; i < mScreenManager.GetScreenCount() - 1; i++)
             {
                 mScreenManager.RemoveScreen();

--- a/Singularity/Singularity/Screen/ScreenClasses/MenuBackgroundScreen.cs
+++ b/Singularity/Singularity/Screen/ScreenClasses/MenuBackgroundScreen.cs
@@ -89,6 +89,8 @@ namespace Singularity.Screen.ScreenClasses
                     mTransitionDuration = 300;
                     break;
                 case EScreen.GameModeSelectScreen:
+                    mTransitionTargetValue = 2f;
+                    mTransitionDuration = 300;
                     break;
                 case EScreen.LoadSelectScreen:
                     break;

--- a/Singularity/Singularity/Screen/ScreenClasses/OptionsScreen.cs
+++ b/Singularity/Singularity/Screen/ScreenClasses/OptionsScreen.cs
@@ -606,22 +606,16 @@ namespace Singularity.Screen.ScreenClasses
         /// <param name="eventArgs"></param>
         private void OnFullScreenReleased(Object sender, EventArgs eventArgs)
         {
-            int width;
-            int height;
-
             if (mGame.mGraphics.IsFullScreen)
             {
                 GlobalVariables.IsFullScreen = false;
                 // if it is already full screen, reset to a smaller screen size
-                width = 960;
-                height = 720;
+                GlobalVariables.ChosenResolution = 0;
             }
             else
             {
                 // otherwise, do set up the game for full screen
                 GlobalVariables.IsFullScreen = true;
-                width = mGame.mGraphicsAdapter.CurrentDisplayMode.Width;
-                height = mGame.mGraphicsAdapter.CurrentDisplayMode.Height;
             }
 
             mGame.mGraphics.IsFullScreen = GlobalVariables.IsFullScreen;
@@ -648,7 +642,7 @@ namespace Singularity.Screen.ScreenClasses
             }
             else
             {
-                GlobalVariables.ChosenResolution = 0;
+                
                 width = GlobalVariables.ResolutionList[GlobalVariables.ChosenResolution].Item1;
                 height = GlobalVariables.ResolutionList[GlobalVariables.ChosenResolution].Item2;
             }

--- a/Singularity/Singularity/Screen/ScreenClasses/WinScreen.cs
+++ b/Singularity/Singularity/Screen/ScreenClasses/WinScreen.cs
@@ -202,6 +202,7 @@ namespace Singularity.Screen.ScreenClasses
 
         private void ReturnToMainMenu(object sender, EventArgs eventArgs)
         {
+            mDirector.GetStoryManager.Level.GameScreen.Unload();
             for (var i = 0; i < mScreenManager.GetScreenCount() - 1; i++)
             {
                 mScreenManager.RemoveScreen();


### PR DESCRIPTION
- Full screen now works properly
- Fixed issue where turning on the game after exiting it in full screen would break it
- Fixed issue where leaving the game and going back to the main menu would break the background
- Fixed issue where going back to the main menu after winning or losing would not remove the previous game objects from the input manager